### PR TITLE
An eddy-diffusivity mass-flux scheme

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,7 @@ makedocs(
                 "Boundary layer models" => Any[
                   "models/basics.md",
                   "models/kpp.md",
+                  "models/edmf.md",
                   "models/pacanowskiphilander.md"],
                 "DocStrings" => Any[
                       "man/types.md",

--- a/docs/src/models/edmf.md
+++ b/docs/src/models/edmf.md
@@ -1,0 +1,132 @@
+# The eddy-diffusivity mass-flux (EDMF) schemes
+
+```math
+\newcommand{\c}         {\, ,}
+\newcommand{\p}         {\, .}
+\newcommand{\d}         {\partial}
+\newcommand{\r}[1]      {\mathrm{#1}}
+\newcommand{\b}[1]      {\boldsymbol{#1}}
+\newcommand{\ee}        {\mathrm{e}}
+\newcommand{\di}        {\, \mathrm{d}}
+\newcommand{\ep}        {\epsilon}
+
+\newcommand{\beq}       {\begin{equation}}
+\newcommand{\eeq}       {\end{equation}}
+\newcommand{\beqs}      {\begin{gather}}
+\newcommand{\eeqs}      {\end{gather}}
+
+% Non-dimensional numbers
+\newcommand{\Ri}        {\mathrm{Ri}}
+\newcommand{\K}         {\mathrm{KE}}        
+
+\newcommand{\btau}      {\b{\tau}} % wind stress vector
+
+% Model functions and constants
+\renewcommand{\F}[2]      {\Upsilon^{#1}_{#2}}
+\renewcommand{\C}[2]      {C^{#1}_{#2}}
+
+\newcommand{\uwind}     {\varpi_{\tau}}
+\newcommand{\ubuoy}     {\varpi_b}
+
+\newcommand{\defn}      {\stackrel{\r{def}}{=}}
+```
+
+The EDMF family of schemes parameterizes turbulent convection by introducing a
+conditional average that partitions the subgrid boundary layer flow into a
+turbulent 'environment' with area ``a_0``,
+and non-turbulent updrafts and downdrafts with areas ``a_i`` for ``i>0``.
+
+We consider two types of EDMF schemes: those with prognostic equations
+that model the time-evolution and spatial distribution of turbulent kinetic
+energy (TKE), and those that parameterize the effect of turbulent environmental
+mixing with a 'K-profile'.
+
+## Turbulent eddy diffusivty and mass flux
+
+In all schemes, the turbulent velocity fluxes are parameterized with an
+eddy diffusivity.
+For the ``x``-velocity ``U``, for example,
+
+```math
+\beq
+\overline{w u} = \d_z \left ( K \d_z U \right ) \c
+\eeq
+```
+where ``K`` is the eddy diffusivity.
+We consider various models for eddy diffusivity ranging from a model similar to
+the K-profile parameterizaton (KPP), and a formulation
+in terms of a prognostic, time- and ``z``-dependent turbulent kinetic energy
+variable, ``e``.
+The turbulent flux of scalars ``\phi`` such as temperature and salinity
+is parameterized by both a turbulent flux and mass transport,
+
+```math
+\beq
+\overline{u \phi} = \d_z \left ( K \d_z \Phi \right )
+  - \d_z \sum_i a_i W^*_i \Phi^*_i \c
+\eeq
+```
+where ``\Phi^*_i`` is the difference between the average of
+``\phi`` within domain ``i`` and the total horizontal average ``\Phi``:
+
+```math
+\begin{align}
+\Phi^*_i &\defn \left ( \frac{1}{A_i} \int_{A_i} \r{d} A - \frac{1}{A} \int_A \r{d} A \right ) \phi \c \\
+&= \Phi_i - \Phi \c
+\end{align}
+```
+where we have introduced the notation ``\Phi_i`` to denote the average of ``\phi`` within
+the environment or updraft area ``A_i``.
+The terms ``a_i W^*_i \Phi^*_i`` account for the vertical transport of ``\phi``
+by environment and updraft vertical velocities ``W_i``.
+
+## Zero-plume, 1.5-order EDMF scheme
+
+A relatively simple EDMF scheme arises in the limit of vanishing updrafts
+and downdrafts, in which case ``W = W_0 = a_0 = 0``.
+In the 1.5-order version of this closure, turbulent diffusivity is modeled
+via the prognostic turbulent kinetic energy (TKE) equation
+
+```math
+\beq
+\d_t e = K \left [ \left ( \d_z U \right )^2 + \left ( \d_z V \right )^2 \right ] + \d_z \left ( K \d_z e \right )
+  + K \d_z B - \C{\ep}{} \frac{e^{3/2}}{\F{\ell}{}} \c
+\eeq
+```
+where ``\C{\ep}{} = 2.0`` is a model parameter,
+``\d_z B = g \left( \alpha \d_z T - \beta \d_z S \right )`` is the buoyancy gradient in terms of gravitational acceleration ``g`` and thermal expansion and haline contraction coefficients ``\alpha`` and ``\beta``,
+and ``K`` is the eddy diffusivity defined in terms of turbulent 'velocity' ``\sqrt{e}`` and a mixing length ``\F{\ell}{}``:
+
+```math
+\beq
+K = \C{K}{} \underbrace{
+      \C{\kappa}{} z \left ( 1 - \F{b}{} \tfrac{F_b}{\uwind^3} z \right )^{\F{n}{}}}
+        _{\defn \F{\ell}{}}
+        \, \sqrt{e} \p
+        \label{eddydiffusivity}
+\eeq
+```
+In \eqref{eddydiffusivity}, ``F_b = g \left ( \alpha F_\theta - \beta F_s \right )`` is the buoyancy flux define in terms of temperature and salinity fluxes ``F_\theta`` and ``F_s``, and ``\uwind \defn | \b{F}_u |^{1/2}`` is the friction velocity defined in terms of velocity flux ``\b{F}_u = \b{\tau} / \rho_0`` or wind-stress ``\b{\tau}`` and reference density ``\rho_0``.
+``\C{\kappa}{} = 0.41`` and ``\C{K}{} = 0.1`` in \eqref{eddydiffusivity} are the 'Von Karman' and eddy diffusivity model parameters, respectively.
+``\F{b}{}`` and ``\F{n}{}`` in \eqref{eddydiffusivity} are piecewise constant model functions
+that model the effect of boundary layer stability on the mixing length and are
+
+```math
+\beq
+\F{b}{} = \left \{ \begin{matrix}
+-100 & \text{for unstable boundary layers with } F_b > 0 \\
+2.7 & \text{for stable boundary layers with } F_b \le 0
+\end{matrix} \right . \c
+\eeq
+```
+
+and
+
+```math
+\beq
+\F{n}{} = \left \{ \begin{matrix}
+0.2 & \text{for unstable boundary layers with } F_b > 0 \\
+-1 & \text{for stable boundary layers with } F_b \le 0
+\end{matrix} \right . \p
+\eeq
+```

--- a/docs/src/models/edmf.md
+++ b/docs/src/models/edmf.md
@@ -82,7 +82,7 @@ by environment and updraft vertical velocities ``W_i``.
 
 ## Zero-plume, 1.5-order EDMF scheme
 
-A relatively simple EDMF scheme arises in the limit of vanishing updrafts
+A relatively simple EDMF scheme emerges in the limit of vanishing updrafts
 and downdrafts, in which case ``W = W_0 = a_0 = 0``.
 In the 1.5-order version of this closure, turbulent diffusivity is modeled
 via the prognostic turbulent kinetic energy (TKE) equation
@@ -90,7 +90,8 @@ via the prognostic turbulent kinetic energy (TKE) equation
 ```math
 \beq
 \d_t e = K \left [ \left ( \d_z U \right )^2 + \left ( \d_z V \right )^2 \right ] + \d_z \left ( K \d_z e \right )
-  + K \d_z B - \C{\ep}{} \frac{e^{3/2}}{\F{\ell}{}} \c
+  - K \d_z B - \C{\ep}{} \frac{e^{3/2}}{\F{\ell}{}} \c
+  \label{TKE}
 \eeq
 ```
 where ``\C{\ep}{} = 2.0`` is a model parameter,
@@ -100,7 +101,7 @@ and ``K`` is the eddy diffusivity defined in terms of turbulent 'velocity' ``\sq
 ```math
 \beq
 K = \C{K}{} \underbrace{
-      \C{\kappa}{} z \left ( 1 - \F{b}{} \tfrac{F_b}{\uwind^3} z \right )^{\F{n}{}}}
+      \C{\kappa}{} z \left ( 1 - \F{a}{} \tfrac{F_b}{\uwind^3} z \right )^{\F{n}{}}}
         _{\defn \F{\ell}{}}
         \, \sqrt{e} \p
         \label{eddydiffusivity}
@@ -108,12 +109,12 @@ K = \C{K}{} \underbrace{
 ```
 In \eqref{eddydiffusivity}, ``F_b = g \left ( \alpha F_\theta - \beta F_s \right )`` is the buoyancy flux define in terms of temperature and salinity fluxes ``F_\theta`` and ``F_s``, and ``\uwind \defn | \b{F}_u |^{1/2}`` is the friction velocity defined in terms of velocity flux ``\b{F}_u = \b{\tau} / \rho_0`` or wind-stress ``\b{\tau}`` and reference density ``\rho_0``.
 ``\C{\kappa}{} = 0.41`` and ``\C{K}{} = 0.1`` in \eqref{eddydiffusivity} are the 'Von Karman' and eddy diffusivity model parameters, respectively.
-``\F{b}{}`` and ``\F{n}{}`` in \eqref{eddydiffusivity} are piecewise constant model functions
+``\F{a}{}`` and ``\F{n}{}`` in \eqref{eddydiffusivity} are piecewise constant model functions
 that model the effect of boundary layer stability on the mixing length and are
 
 ```math
 \beq
-\F{b}{} = \left \{ \begin{matrix}
+\F{a}{} = \left \{ \begin{matrix}
 -100 & \text{for unstable boundary layers with } F_b > 0 \\
 2.7 & \text{for stable boundary layers with } F_b \le 0
 \end{matrix} \right . \c
@@ -130,3 +131,6 @@ and
 \end{matrix} \right . \p
 \eeq
 ```
+
+Note that parameterized buoyancy flux ``\overline{w b} \defn -K \d_z B`` appears in the
+TKE equation \eqref{TKE}.

--- a/src/OceanTurb.jl
+++ b/src/OceanTurb.jl
@@ -92,7 +92,7 @@ export # This file, core functionality:
     KPP,
     PacanowskiPhilander,
     ContinuousAdjustment,
-    EDMF
+    EDMF0
 
 using
     StaticArrays,

--- a/src/OceanTurb.jl
+++ b/src/OceanTurb.jl
@@ -91,7 +91,8 @@ export # This file, core functionality:
     Diffusion,
     KPP,
     PacanowskiPhilander,
-    ContinuousAdjustment
+    ContinuousAdjustment,
+    EDMF
 
 using
     StaticArrays,
@@ -194,5 +195,6 @@ include("models/diffusion.jl")
 include("models/k_profile_parameterization.jl")
 include("models/pacanowski_philander.jl")
 include("models/continuous_convective_adjustment.jl")
+include("models/eddy_diffusivity_mass_flux.jl")
 
 end # module

--- a/src/models/eddy_diffusivity_mass_flux.jl
+++ b/src/models/eddy_diffusivity_mass_flux.jl
@@ -1,0 +1,162 @@
+module EDMF
+
+using
+    OceanTurb,
+    StaticArrays,
+    LinearAlgebra
+
+import OceanTurb: ∇K∇c, ∇K∇c_bottom, ∇K∇c_top, Constants
+import OceanTurb: oncell
+
+import .KPP: ∂B∂z
+
+const nsol = 5
+@specify_solution CellField U V T S e
+
+"""
+    Parameters(; kwargs...)
+
+Construct KPP parameters.
+
+    Args
+    ====
+    Cε : Surface layer fraction
+    etc.
+"""
+struct Parameters{T} <: AbstractParameters
+    Cε      :: T  # Surface layer fraction
+    Cκ      :: T  # Von Karman constant
+    CK      :: T  # Minimum unresolved turbulence kinetic energy
+
+    Ca_stab :: T  # Stable buoyancy flux parameter for wind-driven turbulence
+    Ca_unst :: T  # Unstable buoyancy flux parameter for wind-driven turbulence
+
+    Cn_stab :: T  # Stable buoyancy flux parameter for wind-driven turbulence
+    Cn_unst :: T  # Unstable buoyancy flux parameter for wind-driven turbulence
+
+    KU₀   :: T  # Interior viscosity for velocity
+    KT₀   :: T  # Interior diffusivity for temperature
+    KS₀   :: T  # Interior diffusivity for salinity
+end
+
+function Parameters(T=Float64;
+         Cε = 2.0,
+         Cκ = 0.41,
+         CK = 0.1,
+    Ca_stab = 2.7,
+    Ca_unst = -100,
+    Cn_stab = 0.2,
+    Cn_unst = -1,
+        KU₀ = 1e-6,
+        KT₀ = 1e-7,
+        KS₀ = 1e-9
+    )
+
+    Parameters{T}(Cε, Cκ, CK, Ca_stab, Ca_unst, Cn_stab, Cn_unst, KU₀, KT₀, KS₀)
+end
+
+mutable struct State{T} <: FieldVector{5, T}
+    Fu :: T
+    Fv :: T
+    Fθ :: T
+    Fs :: T
+    Fb :: T
+end
+
+State(T=Float64) = State{T}(0, 0, 0, 0, 0)
+
+"""
+    update_state!(model)
+
+Update the top flux conditions and mixing depth for `model`
+and store in `model.state`.
+"""
+function update_state!(m)
+    m.state.Fu = getbc(m, m.bcs.U.top)
+    m.state.Fv = getbc(m, m.bcs.V.top)
+    m.state.Fθ = getbc(m, m.bcs.T.top)
+    m.state.Fs = getbc(m, m.bcs.S.top)
+    m.state.Fb = m.constants.g * (m.constants.α * m.state.Fθ - m.constants.β * m.state.Fs)
+    return nothing
+end
+
+struct Model{TS, G, T} <: AbstractModel{TS, G, T}
+    @add_standard_model_fields
+    parameters :: Parameters{T}
+    constants  :: Constants{T}
+    state      :: State{T}
+end
+
+function Model(; N=10, L=1.0,
+            grid = UniformGrid(N, L),
+       constants = Constants(),
+      parameters = Parameters(),
+         stepper = :ForwardEuler,
+             bcs = BoundaryConditions((ZeroFluxBoundaryConditions() for i=1:nsol)...)
+    )
+
+    solution = Solution((CellField(grid) for i=1:nsol)...)
+    timestepper = Timestepper(stepper, calc_rhs_explicit!, solution)
+
+    return Model(Clock(), grid, timestepper, solution, bcs, parameters, constants, State())
+end
+
+
+# Note: to increase readability, we use 'm' to refer to 'model' in function
+# definitions below.
+#
+
+mixing_length(Cκ, Ca, Cn, Fb, ωτ, z) = Cκ * z * (1 - z * Ca * Fb / ωτ^3)^Cn
+
+function mixing_length(m, z, i)
+    if isunstable(m)
+        mixing_length(m.parameters.Cκ,
+                      m.parameters.Ca_unst, m.parameters.Cn_unst, ωτ(m), z)
+    else
+        mixing_length(m.parameters.Cκ,
+                      m.parameters.Ca_stab, m.parameters.Cn_stab, ωτ(m), z)
+    end
+    return nothing
+end
+
+K(m, i) = m.parameters.CK * mixing_length(m, m.grid.zf[i], i) * sqrt(m.solution.e[i])
+
+oncell(f::Function, m, i) = 0.5 * (f(m, i) + f(m, i+1))
+
+turb_production(m, i) = K(m, i) * (∂z(m.solution.U, i)^2 + ∂z(m.solution.V, i)^2)
+wb(m, i) = -K(m, i) * ∂B∂z(m, i)
+
+#
+# Equation entry
+#
+
+function calc_rhs_explicit!(∂t, m)
+
+    # Preliminaries
+    update_state!(m)
+    U, V, T, S, e = m.solution
+
+    N = m.grid.N
+    update_ghost_cells!(U, K(m, 1), K(m, N), m, m.bcs.U)
+    update_ghost_cells!(V, K(m, 1), K(m, N), m, m.bcs.V)
+    update_ghost_cells!(T, K(m, 1), K(m, N), m, m.bcs.T)
+    update_ghost_cells!(S, K(m, 1), K(m, N), m, m.bcs.S)
+    update_ghost_cells!(e, K(m, 1), K(m, N), m, m.bcs.e)
+
+    for i in eachindex(U)
+        @inbounds begin
+            ∂t.U[i] = ∇K∇c(K(m, i+1), K(m, i), U, i) + m.constants.f * V[i]
+            ∂t.V[i] = ∇K∇c(K(m, i+1), K(m, i), V, i) - m.constants.f * U[i]
+            ∂t.T[i] = ∇K∇c(K(m, i+1), K(m, i), T, i)
+            ∂t.S[i] = ∇K∇c(K(m, i+1), K(m, i), S, i)
+            ∂t.e[i] = (
+                ∇K∇c(K(m, i+1), K(m, i), e, i)
+                + oncell(turb_production, m, i) + oncell(wb, m, i)
+                - m.parameters.Cε * e[i]^(3/2) / mixing_length(m, m.grid.zc[i], i))
+        end
+    end
+
+    return nothing
+end
+
+end # module

--- a/src/models/eddy_diffusivity_mass_flux.jl
+++ b/src/models/eddy_diffusivity_mass_flux.jl
@@ -1,4 +1,4 @@
-module EDMF
+module EDMF0
 
 using
     OceanTurb,

--- a/test/edmftests.jl
+++ b/test/edmftests.jl
@@ -1,0 +1,9 @@
+#
+# Tests for the Diffusion module
+#
+
+function test_edmf_basic()
+    parameters = EDMF0.Parameters(Cκ=0.42)
+    model = EDMF0.Model(N=4, L=2, parameters=parameters)
+    model.parameters.Cκ == 0.42
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,3 +116,8 @@ end
     @test test_pp_basic()
     @test test_pp_diffusion_cosine()
 end
+
+@testset "EDMF0" begin
+    include("edmftests.jl")
+    @test test_edmf_basic()
+end


### PR DESCRIPTION
This PR throws together an eddy-diffusivity mass-flux scheme for `OceanTurb.jl`. 

We've only implemented the simplest case with no plumes, which we are calling `EDMF0`. A generalization will be needed later.

The scheme does not yet have physics tests.