### PR TITLE
New Equation abstraction system

### DIFF
--- a/src/OceanTurb.jl
+++ b/src/OceanTurb.jl
@@ -125,6 +125,7 @@ include("solvers.jl")
 include("grids.jl")
 include("boundary_conditions.jl")
 include("fields.jl")
+include("equations.jl")
 include("timesteppers.jl")
 
 mutable struct Clock{T}

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -1,0 +1,23 @@
+"""
+    Equation(R, K)
+
+Construct an Equation that represents a PDE of the form
+
+    ∂ϕ/∂t = ∂/∂z (K ∂ϕ/∂z) + R ,
+
+so that K is a diffusivity and R captures 'remaining' terms.
+
+In OceanTurb, K and R are arrays of functions.
+The functions K[j](m, i) and R[j](m, i) calculate the
+diffusivity K and remaining terms R for the model `m` at
+grid point `i`.
+"""
+struct Equation{TR, TK}
+    R       :: TR
+    K       :: TK
+    update! :: Function
+end
+
+nothing_func(args...) = nothing
+
+Equation(R, K) = Equation(R, K, nothing_func)

--- a/test/diffusiontests.jl
+++ b/test/diffusiontests.jl
@@ -3,19 +3,19 @@
 #
 
 function test_diffusion_basic()
-    model = Diffusion.Model(N=4, L=2, κ=0.1)
-    model.parameters.κ == 0.1
+    model = Diffusion.Model(N=4, L=2, K=0.1)
+    model.parameters.K == 0.1
 end
 
 function test_diffusion_set_c()
-    model = Diffusion.Model(N=4, L=2, κ=0.1)
+    model = Diffusion.Model(N=4, L=2, K=0.1)
     c0 = 1:4
     model.solution.c = c0
     model.solution.c.data[1:model.grid.N] == c0
 end
 
 function test_diffusive_flux(stepper=:ForwardEuler; top_flux=0.3, bottom_flux=0.13, N=10)
-    model = Diffusion.Model(N=N, L=1, κ=1, stepper=stepper)
+    model = Diffusion.Model(N=N, L=1, K=1, stepper=stepper)
     model.bcs.c.top = FluxBoundaryCondition(top_flux)
     model.bcs.c.bottom = FluxBoundaryCondition(bottom_flux)
 
@@ -29,7 +29,7 @@ function test_diffusive_flux(stepper=:ForwardEuler; top_flux=0.3, bottom_flux=0.
 end
 
 function test_diffusion_cosine(stepper=:ForwardEuler)
-    model = Diffusion.Model(N=100, L=π/2, κ=1, stepper=stepper)
+    model = Diffusion.Model(N=100, L=π/2, K=1, stepper=stepper)
     z = model.grid.zc
 
     c_init(z) = cos(2z)


### PR DESCRIPTION
This PR implements a new equation abstraction system that should prevent bugs like #19 from occurring in the future.

As explained in the new docs, an 'equation' in `OceanTurb` is expressed as the sum of a diffusive term and general nonlinear function:

```
∂ϕ/∂t = (∂/∂z K ∂/∂z) ϕ + R(ϕ)
```

Thus, implementing a model in `OceanTurb` requires specifying the 'diffusivity' `K` for each field, and a function `R` for each field. In the case that no `R` exists for one or more of the equations, it may be set to either `0` or `nothing` (setting it to `nothing` avoids evaluating `R` altogether, which may be more performant than adding `0`.)

For semi-implicit timesteppers, the diffusive term is treated implicitly. Otherwise it is treated explicitly.