### PR TITLE
KPP parameter reorganization

### DIFF
--- a/docs/src/models/kpp.md
+++ b/docs/src/models/kpp.md
@@ -17,7 +17,8 @@
 
 % Non-dimensional numbers
 \newcommand{\Ri}        {\mathrm{Ri}}
-\newcommand{\K}         {\mathrm{KE}}        
+\newcommand{\SL}        {\mathrm{SL}}
+\newcommand{\K}         {\mathcal{E}}
 
 \newcommand{\btau}      {\b{\tau}} % wind stress vector
 
@@ -27,6 +28,8 @@
 
 \newcommand{\uwind}     {\omega_{\tau}}
 \newcommand{\ubuoy}     {\omega_b}
+
+\newcommand{\NL}        {NL}
 ```
 
 The K-Profile-Parameterization, or "KPP", is proposed by
@@ -36,12 +39,12 @@ In KPP, vertical turbulent fluxes of a quantity ``\phi`` are parameterized as
 
 ```math
 \beq
-\overline{w \phi} = - K_\Phi \d_z \Phi + N_\phi \c
+\overline{w \phi} = - K_\phi \d_z \Phi + \NL_\phi \c
 \eeq
 ```
 
-where ``\Phi`` is the resolved or horizontally-averaged quantity, ``K_\Phi`` is a
-turbulent diffusivity, and ``N_\phi`` is a 'non-local' flux.
+where ``\Phi`` is the resolved or horizontally-averaged quantity, ``K_\phi`` is a
+turbulent diffusivity, and ``NL_\phi`` is a 'non-local' flux.
 
 The non-local flux and turbulent diffusivity are defined to vanish at the surface, and at the bottom of the 'mixing layer' ``h``, which roughly
 corresponds to the depth at which turbulent fluxes and turbulent kinetic energy
@@ -130,10 +133,10 @@ The non-local flux is defined only for ``T`` and ``S``, and is
 
 ```math
 \beq
-N_\Phi = \C{N}{} F_\Phi d (1 - d)^2 \c
+NL_\phi = \C{\NL}{} F_\phi d (1 - d)^2 \c
 \eeq
 ```
-where ``d = -z/h`` is a non-dimensional depth coordinate and ``\C{N}{} = 6.33``.
+where ``d = -z/h`` is a non-dimensional depth coordinate and ``\C{\NL}{} = 6.33``.
 
 ### Turbulent Diffusivity
 
@@ -141,19 +144,19 @@ The KPP diffusivity is defined
 
 ```math
 \beq
-K_\Phi = h \F{w}{\Phi} d ( 1 - d )^2 \c
+K_\phi = h \F{w}{\phi} d ( 1 - d )^2 \c
 \eeq
 ```
-where ``\F{w}{\Phi}`` is the turbulent velocity scale.
+where ``\F{w}{\phi}`` is the turbulent velocity scale.
 In wind-driven turbulence under stable buoyancy forcing such that ``F_b < 0``, the turbulent velocity scale is
 
 ```math
 \beq
-\F{w}{\Phi} = \frac{ \C{\kappa}{} \uwind}{1 + \C{\mathrm{stab}}{} r_b d} \p
+\F{w}{\phi} = \frac{ \C{\tau}{} \uwind}{1 + \C{\mathrm{stab}}{} r_b d} \p
 \eeq
 ```
 
-wherea ``\C{\kappa}{} = 0.4`` is the Von Karman constant and ``\C{\mathrm{stab}}{} = 2.0``.
+wherea ``\C{\tau}{} = 0.4`` is the Von Karman constant and ``\C{\mathrm{stab}}{} = 2.0``.
 
 In wind-driven turbulence but under destabilizing buoyancy forcing, when ``\min \left [ \C{\ep}{}, d \right ] < \C{d}{\phi} r_\tau``,
 the turbulent velocity scale is
@@ -296,11 +299,39 @@ Under zero buoyancy forcing, the turbulent velocity scale is
 
 # Table of model parameters
 
-The model parameters in KPP are
+The default values for adjustable model parameters in KPP are
 
-|   Parameter   | Value | Reference              |
-|   :-------:   | :---: | ---------              |
-| ``\C{\ep}{}`` | 0.1   | pretty much everywhere |
+|   Parameter             | Value   |
+|   :-------:             | :---:   |
+| ``\C{\Ri}{}``           | 0.3     |
+| ``\C{\SL}{}``           | 0.1     |
+| ``\C{\K}{}``            | 3.19    |
+| ``\C{\NL}{}``           | 6.33    |
+| ``\C{\tau}{}``          | 0.4     |
+| ``\C{\mathrm{stab}}{}`` | 2.0     |
+| ``\C{\mathrm{unst}}{}`` | 6.4     |
+| ``\C{b}{U}``            | 0.599   |
+| ``\C{b}{T}``            | 1.36    |
+| ``\C{d}{U}``            | 0.5     |
+| ``\C{d}{T}``            | 2.5     |
+| ``\C{n}{}``             | 1.0     |
+| ``\C{m\tau}{U}``        | 0.25    |
+| ``\C{m\tau}{T}``        | 0.5     |
+| ``\C{mb}{U}``           | 0.33    |
+| ``\C{mb}{T}``           | 0.33    |
+| ``K_{u0}``              | 10^{-5} |
+| ``K_{T0}``              | 10^{-5} |
+| ``K_{S0}``              | 10^{-5} |
+
+Note: all parameters are greater than 0, and ``0 \ge \C{\SL}{} \ge 1``.
+
+The default values for 'non-adjustable' parameters in KPP are
+
+|   Parameter       | Value |
+|   :-------:       | :---: |
+| ``\C{\tau b}{U}`` | ----  |
+| ``\C{\tau b}{T}`` | ----  |
+| ``\C{\K_0}{}``    | 1e-11 |
 
 
 # References

--- a/docs/src/models/kpp.md
+++ b/docs/src/models/kpp.md
@@ -110,11 +110,11 @@ where the critical ``\Ri`` is ``\C{\Ri}{} = 0.3``. The operator ``\Delta`` is de
 
 ```math
 \beq
-\Delta \Phi(z) = -\frac{1}{\C{\ep}{} z} \int_{\C{\ep}{} z}^0 \Phi(z') \di z' - \Phi(z) \c
+\Delta \Phi(z) = -\frac{1}{\C{\SL}{} z} \int_{\C{\SL}{} z}^0 \Phi(z') \di z' - \Phi(z) \c
 \eeq
 ```
 
-where ``\C{\ep}{} = 0.1`` is the surface layer fraction.
+where ``\C{\SL}{} = 0.1`` is the surface layer fraction.
 The function ``\F{\K}{}(z)`` is
 
 ```math
@@ -152,36 +152,40 @@ In wind-driven turbulence under stable buoyancy forcing such that ``F_b < 0``, t
 
 ```math
 \beq
-\F{w}{\phi} = \frac{ \C{\tau}{} \uwind}{1 + \C{\mathrm{stab}}{} r_b d} \p
+\F{w}{\phi} = \frac{ \C{\tau}{} \uwind}{ \left ( 1 + \C{\mathrm{stab}}{} r_b d \right )^{\C{n}{}}} \p
 \eeq
 ```
 
-wherea ``\C{\tau}{} = 0.4`` is the Von Karman constant and ``\C{\mathrm{stab}}{} = 2.0``.
+where ``\C{\tau}{} = 0.4`` is the Von Karman constant, ``\C{\mathrm{stab}}{} = 2.0``, and ``\C{n}{}=1``.
 
-In wind-driven turbulence but under destabilizing buoyancy forcing, when ``\min \left [ \C{\ep}{}, d \right ] < \C{d}{\phi} r_\tau``,
+In wind-driven turbulence but under destabilizing buoyancy forcing, when ``\min \left [ \C{\SL}{}, d \right ] < \C{d}{\phi} r_\tau``,
 the turbulent velocity scale is
 
 ```math
 \beq
-\F{w}{\Phi} = \C{\kappa}{} \omega_\tau \left ( 1 + \C{\mathrm{unst}}{} r_b \min \left [ \C{\ep}{}, d \right ] \right )^{n_\Phi} \c
+\F{w}{\Phi} = \C{\tau}{} \omega_\tau \left ( 1 + \C{\mathrm{unst}}{} r_b \min \left [ \C{\SL}{}, d \right ] \right )^{\C{m\tau}{\Phi}} \c
 \eeq
 ```
 
-where ``n_U = 1/4`` for velocities, ``n_T = 1/2`` for tracers, ``\C{\mathrm{unst}}{} = 6.4``, the
+where ``\C{m\tau}{U}= 1/4``, ``\C{m\tau}{T} = 1/2``, ``\C{\mathrm{unst}}{} = 6.4``, the
 transition parameter for velocities is ``\C{d}{U} = 0.5``, and the transition parameter
 for tracers is ``\C{d}{T} = 2.5``.
 
-In convection-driven turbulence affected by wind mixing, when ``\min \left [ \C{\ep}{}, d \right ] >= \C{d}{\phi} r_\tau``,
+In convection-driven turbulence affected by wind mixing, when ``\min \left [ \C{\SL}{}, d \right ] >= \C{d}{\phi} r_\tau``,
 the turbulent velocity scale is
 
 ```math
 \beq
-\F{w}{\Phi} = \C{b}{\Phi} \omega_b \left ( \min \left [ \C{\ep}{}, d \right ] + \C{\tau}{\Phi} r_\tau \right )^{1/3} \c
+\F{w}{\Phi} = \C{b}{\Phi} \omega_b \left ( \min \left [ \C{\SL}{}, d \right ] + \C{\tau b}{\Phi} r_\tau \right )^{\C{mb}{\Phi}} \c
 \eeq
 ```
 
-where ``\C{b}{U} = \C{b}{V} = 0.215``, ``\C{b}{T} = \C{b}{S} = 2.53``, ``\C{\tau}{U} = \C{\tau}{V} = 0.0806``, and
-``\C{\tau}{T} = \C{\tau}{S} = 1.85``.
+where
+``\C{b}{U} = \C{b}{V} = 0.215``,
+``\C{b}{T} = \C{b}{S} = 2.53``,
+``\C{mb}{U} = \C{mb}{T}=1/3``,
+``\C{\tau b}{U} = \C{\tau b}{V} = 0.374``, and
+``\C{\tau b}{T} = \C{\tau b}{S} = -0.717``.
 
 
 ## Selected tests
@@ -192,7 +196,7 @@ See `/test/runtests.jl` for more tests.
 
 Some simple tests can be defined when the model state is ``U=V=S=0`` and ``T = \gamma z``.
 In this case the buoyancy becomes ``B = g \alpha \gamma z`` and the buoyancy gradient is ``B_z = g \alpha \gamma``.
-If we further take ``\C{\ep}{} \to 0`` and ``F_b > 0``, and note that the value of ``T``
+If we further take ``\C{\SL}{} \to 0`` and ``F_b > 0``, and note that the value of ``T``
 in the top grid cell is ``T_N = -\gamma \Delta z / 2``, where ``N`` is the number of
 grid points, we find that
 
@@ -255,43 +259,43 @@ and a velocity profile
 
 ```math
 \beq
-U(z) =  \left \{ \begin{matrix}
-  U_0 & \quad \text{for } z > -h \c \\
-  -U_0 & \quad \text{for } z < -h \c
+u(z) =  \left \{ \begin{matrix}
+  u_0 & \quad \text{for } z > -h \c \\
+  -u_0 & \quad \text{for } z < -h \c
   \end{matrix} \right .
 \eeq
 ```
 
-so that ``T(z=-h) = U(z=-h) = 0``.
-We then have ``\Delta T(-h) = T_0`` and ``\Delta U^2(-h) = U_0^2``, so that
+so that ``t(z=-h) = u(z=-h) = 0``.
+we then have ``\delta t(-h) = t_0`` and ``\delta u^2(-h) = u_0^2``, so that
 with ``g=\alpha=1``,
 
 ```math
 \beq
-\C{\Ri}{} = \frac{h T_0}{U_0^2} \p
+\c{\Ri}{} = \frac{h t_0}{u_0^2} \p
 \label{sheardepth}
 \eeq
 ```
-Setting ``h = 9``, ``\C{\Ri}{}=1``, ``T_0 = 1``, and ``U_0=3`` yields a consistent solution.
+setting ``h = 9``, ``\c{\ri}{}=1``, ``t_0 = 1``, and ``u_0=3`` yields a consistent solution.
 
-### Limiting cases for turbulent velocity scales
+### limiting cases for turbulent velocity scales
 
-Under zero momentum forcing, the turbulent vertical velocity scale is
+under zero momentum forcing, the turbulent vertical velocity scale is
 
 ```math
 \beq
-\F{w}{\Phi} = \C{b}{\Phi} \left ( \C{\ep}{} \right )^{1/3} | h F_b |^{1/3} \p
+\f{w}{\phi} = \c{b}{\phi} \left ( \c{\ep}{} \right )^{1/3} | h f_b |^{1/3} \p
 \label{buoyscaletest}
 \eeq
 ```
 
 we write the test in \eqref{buoyscaletest} using the depth in \eqref{analyticaldepth}
 
-Under zero buoyancy forcing, the turbulent velocity scale is
+under zero buoyancy forcing, the turbulent velocity scale is
 
 ```math
 \beq
-\F{w}{\Phi} = \C{\kappa}{} \omega_\tau \p
+\f{w}{\phi} = \c{\tau}{} \omega_\tau \p
 \label{windscaletest}
 \eeq
 ```
@@ -301,27 +305,27 @@ Under zero buoyancy forcing, the turbulent velocity scale is
 
 The default values for adjustable model parameters in KPP are
 
-|   Parameter             | Value   |
-|   :-------:             | :---:   |
-| ``\C{\Ri}{}``           | 0.3     |
-| ``\C{\SL}{}``           | 0.1     |
-| ``\C{\K}{}``            | 3.19    |
-| ``\C{\NL}{}``           | 6.33    |
-| ``\C{\tau}{}``          | 0.4     |
-| ``\C{\mathrm{stab}}{}`` | 2.0     |
-| ``\C{\mathrm{unst}}{}`` | 6.4     |
-| ``\C{b}{U}``            | 0.599   |
-| ``\C{b}{T}``            | 1.36    |
-| ``\C{d}{U}``            | 0.5     |
-| ``\C{d}{T}``            | 2.5     |
-| ``\C{n}{}``             | 1.0     |
-| ``\C{m\tau}{U}``        | 0.25    |
-| ``\C{m\tau}{T}``        | 0.5     |
-| ``\C{mb}{U}``           | 0.33    |
-| ``\C{mb}{T}``           | 0.33    |
-| ``K_{u0}``              | 10^{-5} |
-| ``K_{T0}``              | 10^{-5} |
-| ``K_{S0}``              | 10^{-5} |
+|   Parameter             | Value   | Description |
+|   :-------:             | :---:   | :---:       |
+| ``\C{\Ri}{}``           | 0.3     | Bulk Richardson number criterion |   
+| ``\C{\SL}{}``           | 0.1     | Surface layer fraction |
+| ``\C{\K}{}``            | 3.19    | Unresolved kinetic energy constant |
+| ``\C{\NL}{}``           | 6.33    | Non-local flux proportionality constant |
+| ``\C{\tau}{}``          | 0.4     | Wind mixing constant / von Karman parameter |
+| ``\C{\mathrm{stab}}{}`` | 2.0     | Proportionality constant for effect of stable buoyancy forcing on wind mixing |
+| ``\C{n}{}``             | 1.0     | Exponent for effect of stable buoyancy forcing on wind mixing |
+| ``\C{\mathrm{unst}}{}`` | 6.4     | Proportionality constant for effect of unstable buoyancy forcing on wind mixing |
+| ``\C{m\tau}{U}``        | 0.25    | Exponent for effect of unstable buoyancy forcing on wind mixing of momentum |
+| ``\C{m\tau}{T}``        | 0.5     | Exponent for effect of unstable buoyancy forcing on wind mixing of momentum |
+| ``\C{b}{U}``            | 0.599   | Convective mixing constant for momentum |
+| ``\C{b}{T}``            | 1.36    | Convective mixing constant for scalars |
+| ``\C{d}{U}``            | 0.5     | Transitional normalized depth for unstable mixing of momentum |
+| ``\C{d}{T}``            | 2.5     | Transitional normalized depth for unstable mixing of scalars |
+| ``\C{mb}{U}``           | 0.33    | Exponent for effect of wind on convective mixing of momentum |
+| ``\C{mb}{T}``           | 0.33    | Exponent for effect of wind on convective mixing of scalars |
+| ``K_{u0}``              | 10^{-5} | Interior/background turbulent diffusivity for momentum |
+| ``K_{T0}``              | 10^{-5} | Interior/background turbulent diffusivitry for temperature |
+| ``K_{S0}``              | 10^{-5} | Interior/background turbulent diffusivitry for salinity |
 
 Note: all parameters are greater than 0, and ``0 \ge \C{\SL}{} \ge 1``.
 

--- a/docs/src/models/kpp.md
+++ b/docs/src/models/kpp.md
@@ -305,37 +305,37 @@ under zero buoyancy forcing, the turbulent velocity scale is
 
 The default values for adjustable model parameters in KPP are
 
-|   Parameter             | Value   | Description |
-|   :-------:             | :---:   | :---:       |
-| ``\C{\Ri}{}``           | 0.3     | Bulk Richardson number criterion |   
-| ``\C{\SL}{}``           | 0.1     | Surface layer fraction |
-| ``\C{\K}{}``            | 3.19    | Unresolved kinetic energy constant |
-| ``\C{\NL}{}``           | 6.33    | Non-local flux proportionality constant |
-| ``\C{\tau}{}``          | 0.4     | Wind mixing constant / von Karman parameter |
-| ``\C{\mathrm{stab}}{}`` | 2.0     | Proportionality constant for effect of stable buoyancy forcing on wind mixing |
-| ``\C{n}{}``             | 1.0     | Exponent for effect of stable buoyancy forcing on wind mixing |
-| ``\C{\mathrm{unst}}{}`` | 6.4     | Proportionality constant for effect of unstable buoyancy forcing on wind mixing |
-| ``\C{m\tau}{U}``        | 0.25    | Exponent for effect of unstable buoyancy forcing on wind mixing of momentum |
-| ``\C{m\tau}{T}``        | 0.5     | Exponent for effect of unstable buoyancy forcing on wind mixing of momentum |
-| ``\C{b}{U}``            | 0.599   | Convective mixing constant for momentum |
-| ``\C{b}{T}``            | 1.36    | Convective mixing constant for scalars |
-| ``\C{d}{U}``            | 0.5     | Transitional normalized depth for unstable mixing of momentum |
-| ``\C{d}{T}``            | 2.5     | Transitional normalized depth for unstable mixing of scalars |
-| ``\C{mb}{U}``           | 0.33    | Exponent for effect of wind on convective mixing of momentum |
-| ``\C{mb}{T}``           | 0.33    | Exponent for effect of wind on convective mixing of scalars |
-| ``K_{u0}``              | 10^{-5} | Interior/background turbulent diffusivity for momentum |
-| ``K_{T0}``              | 10^{-5} | Interior/background turbulent diffusivitry for temperature |
-| ``K_{S0}``              | 10^{-5} | Interior/background turbulent diffusivitry for salinity |
+|   Parameter             | Value       | Description |
+|   :-------:             | :---:       | :---:       |
+| ``\C{\Ri}{}``           | 0.3         | Bulk Richardson number criterion |   
+| ``\C{\SL}{}``           | 0.1         | Surface layer fraction |
+| ``\C{\K}{}``            | 3.19        | Unresolved kinetic energy constant |
+| ``\C{\NL}{}``           | 6.33        | Non-local flux proportionality constant |
+| ``\C{\tau}{}``          | 0.4         | Wind mixing constant / von Karman parameter |
+| ``\C{\mathrm{stab}}{}`` | 2.0         | Proportionality constant for effect of stable buoyancy forcing on wind mixing |
+| ``\C{n}{}``             | 1.0         | Exponent for effect of stable buoyancy forcing on wind mixing |
+| ``\C{\mathrm{unst}}{}`` | 6.4         | Proportionality constant for effect of unstable buoyancy forcing on wind mixing |
+| ``\C{m\tau}{U}``        | 0.25        | Exponent for effect of unstable buoyancy forcing on wind mixing of momentum |
+| ``\C{m\tau}{T}``        | 0.5         | Exponent for effect of unstable buoyancy forcing on wind mixing of momentum |
+| ``\C{b}{U}``            | 0.599       | Convective mixing constant for momentum |
+| ``\C{b}{T}``            | 1.36        | Convective mixing constant for scalars |
+| ``\C{d}{U}``            | 0.5         | Transitional normalized depth for unstable mixing of momentum |
+| ``\C{d}{T}``            | 2.5         | Transitional normalized depth for unstable mixing of scalars |
+| ``\C{mb}{U}``           | 0.33        | Exponent for effect of wind on convective mixing of momentum |
+| ``\C{mb}{T}``           | 0.33        | Exponent for effect of wind on convective mixing of scalars |
+| ``K_{u0}``              | ``10^{-5}`` | Interior/background turbulent diffusivity for momentum |
+| ``K_{T0}``              | ``10^{-5}`` | Interior/background turbulent diffusivity for temperature |
+| ``K_{S0}``              | ``10^{-5}`` | Interior/background turbulent diffusivity for salinity |
 
 Note: all parameters are greater than 0, and ``0 \ge \C{\SL}{} \ge 1``.
 
 The default values for 'non-adjustable' parameters in KPP are
 
-|   Parameter       | Value |
-|   :-------:       | :---: |
-| ``\C{\tau b}{U}`` | ----  |
-| ``\C{\tau b}{T}`` | ----  |
-| ``\C{\K_0}{}``    | 1e-11 |
+|   Parameter       | Value  | Description |
+|   :-------:       | :---:  | :-: |
+| ``\C{\tau b}{U}`` | 0.374  | |  
+| ``\C{\tau b}{T}`` | -0.717 | |
+| ``\C{\K_0}{}``    | 1e-11  | |
 
 
 # References

--- a/src/models/k_profile_parameterization.jl
+++ b/src/models/k_profile_parameterization.jl
@@ -16,11 +16,6 @@ const nsol = 4
     Parameters(; kwargs...)
 
 Construct KPP parameters.
-
-    Args
-    ====
-    CSL : Surface layer fraction
-    etc.
 """
 struct Parameters{T} <: AbstractParameters
     CSL   :: T  # Surface layer fraction
@@ -70,13 +65,12 @@ function Parameters(T=Float64;
     Cmτ_T = 1/2,
     Cmb_U = 1/3,
     Cmb_T = 1/3,
-       K₀ = 1e-5, KU₀=K₀, KT₀=K₀, KS₀=K₀
-     # do not change:
+       K₀ = 1e-5, KU₀=K₀, KT₀=K₀, KS₀=K₀,
+     # These should not be changed under ordinary circumstances:
      CKE₀ = 1e-11,
-     )
-
-     Cτb_U = (Cτ / Cb_U)^(1/Cmb_U) * (1 + Cunst*Cd_U)^(Cmτ_U/Cmb_U) - Cd_U
+     Cτb_U = (Cτ / Cb_U)^(1/Cmb_U) * (1 + Cunst*Cd_U)^(Cmτ_U/Cmb_U) - Cd_U,
      Cτb_T = (Cτ / Cb_T)^(1/Cmb_T) * (1 + Cunst*Cd_T)^(Cmτ_T/Cmb_T) - Cd_T
+     )
 
      Parameters{T}(CSL, Cτ, CNL, Cstab, Cunst,
                    Cb_U, Cτb_U, Cb_T, Cτb_T, Cd_U, Cd_T,

--- a/src/models/k_profile_parameterization.jl
+++ b/src/models/k_profile_parameterization.jl
@@ -42,11 +42,11 @@ struct Parameters{T} <: AbstractParameters
     CKE   :: T  # Unresolved turbulence parameter
     CKE₀  :: T  # Minimum unresolved turbulence kinetic energy
 
-       Cn :: T # exponent...
-    Cmτ_U :: T # exponent...
-    Cmτ_T :: T # exponent...
-    Cmb_U :: T # exponent...
-    Cmb_T :: T # exponent...
+       Cn :: T  # Exponent for effect of stable buoyancy forcing on wind mixing
+    Cmτ_U :: T  # Exponent for effect of unstable buoyancy forcing on wind mixing of U
+    Cmτ_T :: T  # Exponent for effect of unstable buoyancy forcing on wind mixing of T
+    Cmb_U :: T  # Exponent for effect of wind on convective mixing of U
+    Cmb_T :: T  # Exponent for effect of wind on convective mixing of T
 
     KU₀   :: T  # Interior viscosity for velocity
     KT₀   :: T  # Interior diffusivity for temperature
@@ -65,13 +65,14 @@ function Parameters(T=Float64;
      Cd_T = 2.5,
       CRi = 4.32,
       CKE = 0.3,
-     CKE₀ = 1e-11,
        Cn = 1.0,
     Cmτ_U = 1/4,
     Cmτ_T = 1/2,
     Cmb_U = 1/3,
     Cmb_T = 1/3,
        K₀ = 1e-5, KU₀=K₀, KT₀=K₀, KS₀=K₀
+     # do not change:
+     CKE₀ = 1e-11,
      )
 
      Cτb_U = (Cτ / Cb_U)^(1/Cmb_U) * (1 + Cunst*Cd_U)^(Cmτ_U/Cmb_U) - Cd_U

--- a/src/timesteppers.jl
+++ b/src/timesteppers.jl
@@ -57,16 +57,23 @@ function update!(m)
     return nothing
 end
 
-explicit_rhs_kernel(ϕ, Kϕ, Rϕ, m, i) = ∇K∇c(Kϕ(m, i+1), Kϕ(m, i), ϕ, i) + Rϕ(m, i)
-explicit_rhs_kernel(ϕ, Kϕ, ::Nothing, m, i) = ∇K∇c(Kϕ(m, i+1), Kϕ(m, i), ϕ, i)
+import Base: +, -, convert
 
-implicit_rhs_top(ϕ, Kϕ, Rϕ, m) = @inbounds ∇K∇c(Kϕ(m, m.grid.N+1), 0, ϕ, m.grid.N) + Rϕ(m, m.grid.N)
-implicit_rhs_top(ϕ, Kϕ, ::Nothing, m) = @inbounds ∇K∇c(Kϕ(m, m.grid.N+1), 0, ϕ, m.grid.N)
+# A whole bunch of nothing.
++(a::Number, ::Nothing) = a
+-(a::Number, ::Nothing) = a
+convert(::Type{T}, ::Nothing) where T<:Number = zero(T)
 
-implicit_rhs_bottom(ϕ, Kϕ, Rϕ, m) = @inbounds ∇K∇c(0, Kϕ(m, 1), ϕ, 1) + Rϕ(m, 1)
-implicit_rhs_bottom(ϕ, Kϕ, ::Nothing, m) = @inbounds ∇K∇c(0, Kϕ(m, 1), ϕ, 1)
+explicit_rhs_kernel(ϕ, K, R, m, i)         = ∇K∇c(K(m, i+1), K(m, i), ϕ, i) + R(m, i)
+explicit_rhs_kernel(ϕ, K, ::Nothing, m, i) = ∇K∇c(K(m, i+1), K(m, i), ϕ, i)
 
-implicit_rhs_kernel!(rhs, ϕ, R, m, i) = rhs[i] = R(m, i)
+implicit_rhs_top(ϕ, K, R, m)         = @inbounds ∇K∇c(K(m, m.grid.N+1), 0, ϕ, m.grid.N) + R(m, m.grid.N)
+implicit_rhs_top(ϕ, K, ::Nothing, m) = @inbounds ∇K∇c(K(m, m.grid.N+1), 0, ϕ, m.grid.N)
+
+implicit_rhs_bottom(ϕ, K, R, m)         = @inbounds ∇K∇c(0, K(m, 1), ϕ, 1) + R(m, 1)
+implicit_rhs_bottom(ϕ, K, ::Nothing, m) = @inbounds ∇K∇c(0, K(m, 1), ϕ, 1)
+
+implicit_rhs_kernel!(rhs, ϕ, R, m, i)         = rhs[i] = R(m, i)
 implicit_rhs_kernel!(rhs, ϕ, ::Nothing, m, i) = nothing
 
 "Evaluate the right-hand-side of ∂ϕ∂t for the current time-step."


### PR DESCRIPTION
This PR addresses #10 and also renames many KPP parameters to more sensible names. For example, we don't want to call the surface layer fraction `Cε` --- `ε` is commonly associated with turbulent dissipation, which `Cε` has nothing to do with. 

The parameters renamed are

* `Cε` -> `CSL` (for "surface layer")
* `Cκ` -> `Cτ` (better indicating its association with wind-stress, rather than diffusivity `κ`)
* `Cτ_Φ` -> `Cτb_Φ` (because `Cτ` is taken)
* `CN` -> `CNL` (NL for non-local)

In addition, the exponents in the velocity scale functions are now parameters, which implies we have 5 new parameters.

The docs are up to date and the tests pass.