### PR TITLE
Split Field type into CellField and FaceField

### DIFF
--- a/src/OceanTurb.jl
+++ b/src/OceanTurb.jl
@@ -112,7 +112,7 @@ abstract type AbstractParameters end
 abstract type AbstractEquation end
 abstract type Grid{T, A<:AbstractArray} end
 abstract type Timestepper end
-abstract type AbstractField{A<:AbstractArray, G<:Grid} end
+abstract type AbstractField{A<:AbstractArray, G<:Grid, T} end
 abstract type AbstractSolution{N, T} <: FieldVector{N, T} end
 abstract type AbstractModel{T, G, TS} end  # Explain: what is a `Model`?
 

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -33,24 +33,23 @@ that lives on `grid`. Defaults to `Array`.
 New data types (for example, grids that exist on GPUs) must
 implement new array types.
 """
-arraytype(grid::Grid{T}) where T = Array{T,1} # default array type
+arraytype(grid::Grid{T}) where T = Array{T, 1} # default array type
 
 """
-    UniformGrid([A, T], L, N)
+    UniformGrid([T], L, N)
 
 Construct a 1D finite-volume grid with type `T` and array type `A`,
 with `N` cells on the domain `z = [0, L]`.
 A `Grid` has two type parameters: an element type `T`,
-and and an array type `A`. `T` and `A` default to `Float64` and `Array{T,1}`,
-respectively.
+and and a range type `R`. `T` defaults to Float64.
 """
-struct UniformGrid{T, A} <: Grid{T, A}
+struct UniformGrid{T, R} <: Grid{T, R}
   N  :: Int
   L  :: T
   Δc :: T
   Δf :: T
-  zc :: A
-  zf :: A
+  zc :: R
+  zf :: R
 end
 
 function UniformGrid(T, N, L)

--- a/src/timesteppers.jl
+++ b/src/timesteppers.jl
@@ -136,7 +136,7 @@ struct BackwardEulerTimestepper{R, L, ER, EK} <: Timestepper
     end
 end
 
-function Tridiagonal(fld::Field)
+function Tridiagonal(fld::AbstractField)
     T = eltype(fld)
     A = arraytype(fld)
     N = length(fld)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,7 +28,7 @@ macro def(name, definition)
     end
 end
 
-function build_solution(fieldnames, fieldtypes=[Field for name in fieldnames]; name=Symbol(""))
+function build_solution(fieldnames, fieldtypes=[CellField for name in fieldnames]; name=Symbol(""))
     nfields = length(fieldnames)
     solfields = [ :( $(fieldnames[i]) :: $(fieldtypes[i]) ) for i = 1:nfields ]
     bcfields =  [ :( $(fieldnames[i]) :: FieldBoundaryConditions ) for i = 1:nfields ]

--- a/test/fieldtests.jl
+++ b/test/fieldtests.jl
@@ -85,16 +85,16 @@ function test_set_scalar_field(loc, T)
 end
 
 function test_set_array_field(loc, T)
-    grid = UniformGrid(T, 2, 2.0)
-    f = Field(loc, grid)
+    g = UniformGrid(T, 2, 2.0)
+    f = Field(loc, g)
     data = rand(1:10, length(f))
     set!(f, data)
     f.data[1:length(f)] == data
 end
 
 function test_set_function_field(loc, T)
-    grid = UniformGrid(T, 2, 2.0)
-    f = Field(loc, grid)
+    g = UniformGrid(T, 2, 2.0)
+    f = Field(loc, g)
     fcn(z) = z^2
     z = nodes(f)
     set!(f, fcn)


### PR DESCRIPTION
This PR splits the `Field` type into a `CellField` and a `FaceField` and removes the `FieldLocation` type as a parameter (though it is retained for legacy purposes for the time being, it may be removed in the future). 

This PR paves the way for solving #29 because we can now more easily specify the type of the fields of `Solution` (even for heterogeneous fields with 3 type parameters corresponding to the array type, grid type, and element type of the solution fields.