### PR TITLE
Boundary condition reconfigure

### DIFF
--- a/benchmarks/atomic_timestepping_benchmarks.jl
+++ b/benchmarks/atomic_timestepping_benchmarks.jl
@@ -1,0 +1,26 @@
+using Pkg; Pkg.activate("..")
+
+using OceanTurb, Printf, StaticArrays, BenchmarkTools
+
+Ns = (100,)
+steppers = (:ForwardEuler,)
+nts = (100,)
+
+@printf "\nTesting OceanTurb calc rhs...\n"
+for N in Ns
+    for stepper in (:ForwardEuler,)
+        m = Diffusion.Model(N=N, stepper=stepper)
+        #m.bcs.c.top = OceanTurb.ConstantGradientBoundaryCondition(1)
+        m.bcs.c.bottom = OceanTurb.GradientBoundaryCondition(1)
+        Δt = 0.1
+        for nt in nts
+            @printf "stepper: % 16s, N: % 6d, nt: % 6d\n" stepper N nt
+
+            @btime OceanTurb.prepare!($(m.bcs), $(m.timestepper.eqn.K), $(m.solution), $(m.timestepper.eqn.update!), $(m.grid.N), $m)
+            @btime OceanTurb.calc_explicit_rhs!($(m.timestepper.rhs), $(m.timestepper.eqn), $(m.solution), $m)
+            @btime OceanTurb.forward_euler_update!($(m.timestepper.rhs), $(m.solution), $Δt)
+            @btime OceanTurb.tick!($(m.clock), $Δt)
+
+        end
+    end
+end

--- a/benchmarks/calc_rhs_benchmarks.jl
+++ b/benchmarks/calc_rhs_benchmarks.jl
@@ -1,0 +1,86 @@
+using Pkg; Pkg.activate("..")
+
+using OceanTurb, Printf, StaticArrays, BenchmarkTools
+
+Ns = (100,)
+steppers = (:ForwardEuler,)
+nts = (100,)
+
+function manyrhs!(m, n)
+    for i = 1:n
+        OceanTurb.calc_explicit_rhs!(m.timestepper.rhs, m.timestepper.eqn, m.solution, m)
+    end
+    return nothing
+end
+
+function bad_manyrhs!(m, n)
+    s1 = m.solution
+    s2 = m.timestepper.rhs
+    for i = 1:n
+        for j in eachindex(s1)
+            ϕ1 = s1[j]
+            ϕ2 = s2[j]
+            for i in eachindex(ϕ1)
+                @inbounds ϕ1[i] = 2*ϕ2[i]
+            end
+        end
+    end
+    return nothing
+end
+
+function good_functionbarrier_manyrhs!(m, n)
+    s1 = m.solution
+    s2 = m.timestepper.rhs
+    for i = 1:n
+        fakerhs!(s1, s2)
+    end
+    return nothing
+end
+
+function fakerhs!(s1, s2)
+    for j in eachindex(s1)
+        ϕ1 = s1[j]
+        ϕ2 = s2[j]
+        for i in eachindex(ϕ1)
+            @inbounds ϕ1[i] = 2*ϕ2[i]
+        end
+    end
+    return nothing
+end
+
+@printf "\nTesting OceanTurb calc rhs...\n"
+for N in Ns
+    for stepper in (:ForwardEuler,)
+        model = Diffusion.Model(N=N, stepper=stepper)
+        for nt in nts
+            @printf "stepper: % 16s, N: % 6d, nt: % 6d" stepper N nt
+            manyrhs!(model, nt)
+            @btime manyrhs!($model, $nt)
+        end
+    end
+end
+
+@printf "\nTesting a bad method to loop over rhs...\n"
+for N in Ns
+    for stepper in (:ForwardEuler,)
+        model = Diffusion.Model(N=N, stepper=stepper)
+        for nt in nts
+            @printf "stepper: % 16s, N: % 6d, nt: % 6d" stepper N nt
+            bad_manyrhs!(model, nt)
+            @btime bad_manyrhs!($model, $nt)
+        end
+    end
+end
+
+
+@printf "\nTesting a good function barrier method to loop over rhs...\n"
+for N in Ns
+    for stepper in (:ForwardEuler,)
+        model = Diffusion.Model(N=N, stepper=stepper)
+        for nt in nts
+            @printf "stepper: % 16s, N: % 6d, nt: % 6d" stepper N nt
+            good_functionbarrier_manyrhs!(model, nt)
+            @btime good_functionbarrier_manyrhs!($model, $nt)
+        end
+    end
+end

--- a/benchmarks/kpp_benchmarks.jl
+++ b/benchmarks/kpp_benchmarks.jl
@@ -3,12 +3,25 @@ using Pkg; Pkg.activate("..")
 using OceanTurb, Printf
 
 for stepper in (:ForwardEuler, :BackwardEuler)
+    model = Diffusion.Model(N=100, stepper=stepper)
+
+    iterate!(model, 0.1)
+
+    # Measure memory allocation
+    @printf "\nTesting Diffusion with %s...\n" stepper
+    for nt = (10, 100, 1000, 10000)
+        @printf "nt: % 6d" nt
+        @time iterate!(model, 0.1, nt)
+    end
+end
+
+for stepper in (:ForwardEuler, :BackwardEuler)
     model = KPP.Model(N=100, stepper=stepper)
 
     iterate!(model, 0.1)
 
     # Measure memory allocation
-    @printf "\nTesting %s...\n" stepper
+    @printf "\nTesting KPP with %s...\n" stepper
     for nt = (10, 100, 1000, 10000)
         @printf "nt: % 6d" nt
         @time iterate!(model, 0.1, nt)

--- a/src/boundary_conditions.jl
+++ b/src/boundary_conditions.jl
@@ -7,34 +7,32 @@ struct Flux <: BCType end
 struct Gradient <: BCType end
 struct Value <: BCType end
 
-#abstract type BoundaryCondition{B<:Boundary} end
-
-@inline zero_function(args...) = 0
-
 "Return c₁, where c₁ = c₀ + ∂c/∂z * (z₁ - z₀) = c₀ + ∂c/∂z * Δz."
-linear_extrapolation(c₀, ∂c∂z, Δz) = c₀ + ∂c∂z * Δz
+linear_extrap(c₀, ∂c∂z, Δz) = c₀ + ∂c∂z * Δz
 
-getbc(model, bc::Function) = bc(model)
-getbc(model, bc::Number) = bc
+abstract type AbstractBoundaryCondition end
 
-struct BoundaryCondition
-    gradient :: Function
+struct BoundaryCondition{C, T} <: AbstractBoundaryCondition
+    condition :: T
 end
 
-function FluxBoundaryCondition(bc)
-    gradient(c, Δf, κ, model) = -getbc(model, bc) / κ
-    return BoundaryCondition(gradient)
-end
+BoundaryCondition(bctype, bc) = BoundaryCondition{bctype, typeof(bc)}(bc)
+GradientBoundaryCondition(bc) = BoundaryCondition(Gradient, bc)
+FluxBoundaryCondition(bc) = BoundaryCondition(Flux, bc)
+ValueBoundaryCondition(bc) = BoundaryCondition(Value, bc)
 
-function GradientBoundaryCondition(bc)
-    gradient(c, Δf, κ, model) = getbc(model, bc)
-    return BoundaryCondition(gradient)
-end
+struct ZeroFluxBoundaryCondition <: AbstractBoundaryCondition end
 
-function ValueBoundaryCondition(bc)
-    gradient(cᴺ, Δf, κ, model) = 2 * (getbc(model, bc) - cᴺ) / Δf
-    return BoundaryCondition(gradient)
-end
+const BC = BoundaryCondition
+const ZFBC = ZeroFluxBoundaryCondition
+
+getbc(model, ::ZFBC) = 0
+getbc(model, bc::BC{C, <:Number}) where C = bc.condition
+getbc(model, bc::BC{C, <:Function}) where C = bc.condition(model)
+
+gradient(bc::BC{<:Gradient}, model, args...) = getbc(model, bc)
+gradient(bc::BC{<:Flux},     model, κ, args...) = -getbc(model, bc) / κ
+gradient(bc::BC{<:Value},    model, κ, cᴺ, Δf, args...) = 2 * (getbc(model, bc) - cᴺ) / Δf
 
 """
     fill_bottom_ghost_cell!(c, κ, model, bc)
@@ -43,11 +41,8 @@ Update the bottom ghost cell of c given the boundary condition `bc`, `model`, an
 diffusivity `kappa`. `kappa` is used only if a flux boundary condition
 is specified.
 """
-function fill_bottom_ghost_cell!(c, κ, model, bc::BoundaryCondition)
-    @inbounds begin
-        c[0] = linear_extrapolation(
-            c[1], bc.gradient(c[1], -Δf(c.grid, 1), κ, model), -Δc(c.grid, 1))
-    end
+function fill_bottom_ghost_cell!(bc, c, κ, model)
+    @inbounds c[0] = linear_extrap(c[1], gradient(bc, model, κ, c[1], -Δf(c, 1)), -Δc(c, 1))
     return nothing
 end
 
@@ -57,34 +52,18 @@ end
 Update the top ghost cell of `c` given boundary condition `bc`, `model`, and
 diffusivity `kappa`
 """
-function fill_top_ghost_cell!(c, κ, model, bc::BoundaryCondition)
-    N = c.grid.N
-    @inbounds begin
-        c[N+1] = linear_extrapolation(
-            c[N], bc.gradient(c[N], Δf(c.grid, N), κ, model), Δc(c.grid, N+1))
-    end
+function fill_top_ghost_cell!(bc, c, κ, model, N)
+    @inbounds c[N+1] = linear_extrap(c[N], gradient(bc, model, κ, c[N], Δf(c, N)), Δc(c, N+1))
     return nothing
 end
 
-"""
-    fill_ghost_cells!(c, κ, model, bc)
-
-Update the top and bottom ghost cells of `c` for `model`.
-"""
-function fill_ghost_cells!(c, κbottom, κtop, model, fieldbcs)
-    fill_bottom_ghost_cell!(c, κbottom, model, fieldbcs.bottom)
-    fill_top_ghost_cell!(c, κtop, model, fieldbcs.top)
-    return nothing
-end
+fill_bottom_ghost_cell!(::ZFBC, c, args...) = @inbounds c[0] = c[1]
+fill_top_ghost_cell!(::ZFBC, c, κ, model, N) = @inbounds c[N+1] = c[N]
 
 mutable struct FieldBoundaryConditions
-    bottom :: BoundaryCondition
-    top    :: BoundaryCondition
+    bottom :: AbstractBoundaryCondition
+    top    :: AbstractBoundaryCondition
 end
-
-#
-# Boundary condition API
-#
 
 """
     FieldBoundaryConditions(; top=TopBC, bottom=BottomBC)
@@ -92,10 +71,9 @@ end
 Create an instance of `FieldBoundaryConditions` with `top` and `bottom`
 boundary conditions.
 """
-function FieldBoundaryConditions(; bottom = FluxBoundaryCondition(0),
-                                      top = FluxBoundaryCondition(0))
+function FieldBoundaryConditions(; bottom = ZeroFluxBoundaryCondition(),
+                                      top = ZeroFluxBoundaryCondition())
     FieldBoundaryConditions(bottom, top)
 end
 
-"Returns `FieldBoundaryConditions` with zero flux at `top` and `bottom`."
-ZeroFluxBoundaryConditions() = FieldBoundaryConditions() # the default
+ZeroFluxBoundaryConditions() = FieldBoundaryConditions()

--- a/src/models/k_profile_parameterization.jl
+++ b/src/models/k_profile_parameterization.jl
@@ -102,10 +102,10 @@ Update the top flux conditions and mixing depth for `model`
 and store in `model.state`.
 """
 function update_state!(m)
-    m.state.Fu = - m.parameters.KU₀ * m.bcs.U.top.gradient(top(m.solution.U), top(Δf), m.parameters.KU₀, m)
-    m.state.Fv = - m.parameters.KU₀ * m.bcs.V.top.gradient(top(m.solution.V), top(Δf), m.parameters.KU₀, m)
-    m.state.Fθ = - m.parameters.KT₀ * m.bcs.T.top.gradient(top(m.solution.T), top(Δf), m.parameters.KT₀, m)
-    m.state.Fs = - m.parameters.KS₀ * m.bcs.S.top.gradient(top(m.solution.S), top(Δf), m.parameters.KS₀, m)
+    m.state.Fu = getbc(m, m.bcs.U.top)
+    m.state.Fv = getbc(m, m.bcs.V.top)
+    m.state.Fθ = getbc(m, m.bcs.T.top)
+    m.state.Fs = getbc(m, m.bcs.S.top)
     m.state.Fb = m.constants.g * (m.constants.α * m.state.Fθ - m.constants.β * m.state.Fs)
     m.state.h  = mixing_depth(m)
     return nothing

--- a/test/fieldtests.jl
+++ b/test/fieldtests.jl
@@ -2,6 +2,12 @@
 # Define tests
 # --
 
+function fill_ghost_cells!(c, κtop, κbottom, model, fieldbcs)
+    fill_bottom_ghost_cell!(fieldbcs.bottom, c, κbottom, model)
+    fill_top_ghost_cell!(fieldbcs.top, c, κtop, model, c.grid.N)
+    return nothing
+end
+
 function test_cell_field_construction(T, N, L)
     grid = UniformGrid(T, N, L)
     c = CellField(grid)


### PR DESCRIPTION
This PR reimplements the boundary condition method that relies on types and multiple dispatch, which is more performant than using a single boundary condition type + closure.