### PR TITLE
Uses Base.@kwdef to define parameter structs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os: linux
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.0
+      julia: 1.1
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.instantiate();

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: julia
-julia: 1.0
+julia: 1.1
 os: linux
 
 jobs:

--- a/src/models/eddy_diffusivity_mass_flux.jl
+++ b/src/models/eddy_diffusivity_mass_flux.jl
@@ -13,36 +13,20 @@ import .KPP: ∂B∂z
 const nsol = 5
 @prefixed_solution ZeroPlume U V T S e
 
-struct Parameters{T} <: AbstractParameters
-         Cε :: T  # Surface layer fraction
-         Cκ :: T  # Von Karman constant
-         CK :: T  # Minimum unresolved turbulence kinetic energy
+Base.@kwdef struct Parameters{T} <: AbstractParameters
+         Cε :: T = 2.0    # Surface layer fraction
+         Cκ :: T = 0.41   # Von Karman constant
+         CK :: T = 0.1    # Minimum unresolved turbulence kinetic energy
 
-    Ca_stab :: T  # Stable buoyancy flux parameter for wind-driven turbulence
-    Ca_unst :: T  # Unstable buoyancy flux parameter for wind-driven turbulence
+    Ca_stab :: T = 2.7    # Stable buoyancy flux parameter for wind-driven turbulence
+    Ca_unst :: T = -100.0 # Unstable buoyancy flux parameter for wind-driven turbulence
 
-    Cn_stab :: T  # Stable buoyancy flux parameter for wind-driven turbulence
-    Cn_unst :: T  # Unstable buoyancy flux parameter for wind-driven turbulence
+    Cn_stab :: T = 0.2    # Stable buoyancy flux parameter for wind-driven turbulence
+    Cn_unst :: T = -1.0   # Unstable buoyancy flux parameter for wind-driven turbulence
 
-        KU₀ :: T  # Interior viscosity for velocity
-        KT₀ :: T  # Interior diffusivity for temperature
-        KS₀ :: T  # Interior diffusivity for salinity
-end
-
-function Parameters(T=Float64;
-         Cε = 2.0,
-         Cκ = 0.41,
-         CK = 0.1,
-    Ca_stab = 2.7,
-    Ca_unst = -100,
-    Cn_stab = 0.2,
-    Cn_unst = -1,
-        KU₀ = 1e-6,
-        KT₀ = 1e-7,
-        KS₀ = 1e-9
-    )
-
-    Parameters{T}(Cε, Cκ, CK, Ca_stab, Ca_unst, Cn_stab, Cn_unst, KU₀, KT₀, KS₀)
+        KU₀ :: T = 1e-6   # Interior viscosity for velocity
+        KT₀ :: T = 1e-7   # Interior diffusivity for temperature
+        KS₀ :: T = 1e-9   # Interior diffusivity for salinity
 end
 
 mutable struct State{T} <: FieldVector{5, T}

--- a/src/models/k_profile_parameterization.jl
+++ b/src/models/k_profile_parameterization.jl
@@ -14,69 +14,38 @@ const nsol = 4
 
 Construct KPP parameters.
 """
-struct Parameters{T} <: AbstractParameters
-    CSL   :: T  # Surface layer fraction
-    Cτ    :: T  # Von Karman constant
-    CNL   :: T  # Non-local flux proportionality constant
+@Base.kwdef struct Parameters{T<:AbstractFloat} <: AbstractParameters
+    CSL   :: T  = 0.1   # Surface layer fraction
+    Cτ    :: T  = 0.4   # Von Karman constant
+    CNL   :: T  = 6.33  # Non-local flux proportionality constant
 
-    Cstab :: T  # Stable buoyancy flux parameter for wind-driven turbulence
-    Cunst :: T  # Unstable buoyancy flux parameter for wind-driven turbulence
+    Cstab :: T  = 2.0   # Stable buoyancy flux parameter for wind-driven turbulence
+    Cunst :: T  = 6.4   # Unstable buoyancy flux parameter for wind-driven turbulence
 
-    Cb_U  :: T  # Buoyancy flux parameter for convective turbulence
-    Cτb_U :: T  # Wind stress parameter for convective turbulence
-    Cb_T  :: T  # Buoyancy flux parameter for convective turbulence
-    Cτb_T :: T  # Wind stress parameter for convective turbulence
+       Cn :: T  = 1.0   # Exponent for effect of stable buoyancy forcing on wind mixing
+    Cmτ_U :: T  = 0.25  # Exponent for effect of unstable buoyancy forcing on wind mixing of U
+    Cmτ_T :: T  = 0.5   # Exponent for effect of unstable buoyancy forcing on wind mixing of T
+    Cmb_U :: T  = 1/3   # Exponent for the effect of wind on convective mixing of U
+    Cmb_T :: T  = 1/3   # Exponent for effect of wind on convective mixing of T
 
-    Cd_U  :: T  # Wind mixing regime threshold for momentum
-    Cd_T  :: T  # Wind mixing regime threshold for tracers
+    Cd_U  :: T  = 0.5   # Wind mixing regime threshold for momentum
+    Cd_T  :: T  = 2.5   # Wind mixing regime threshold for tracers
 
-    CRi   :: T  # Critical bulk Richardson number
-    CKE   :: T  # Unresolved turbulence parameter
-    CKE₀  :: T  # Minimum unresolved turbulence kinetic energy
+    Cb_U  :: T  = 0.599 # Buoyancy flux parameter for convective turbulence
+    Cb_T  :: T  = 1.36  # Buoyancy flux parameter for convective turbulence
+    Cτb_U :: T  = (Cτ / Cb_U)^(1/Cmb_U) * (1 + Cunst*Cd_U)^(Cmτ_U/Cmb_U) - Cd_U  # Wind stress parameter for convective turbulence
+    Cτb_T :: T  = (Cτ / Cb_T)^(1/Cmb_T) * (1 + Cunst*Cd_T)^(Cmτ_T/Cmb_T) - Cd_T  # Wind stress parameter for convective turbulence
 
-       Cn :: T  # Exponent for effect of stable buoyancy forcing on wind mixing
-    Cmτ_U :: T  # Exponent for effect of unstable buoyancy forcing on wind mixing of U
-    Cmτ_T :: T  # Exponent for effect of unstable buoyancy forcing on wind mixing of T
-    Cmb_U :: T  # Exponent for effect of wind on convective mixing of U
-    Cmb_T :: T  # Exponent for effect of wind on convective mixing of T
+    CRi   :: T  = 0.3   # Critical bulk Richardson number
+    CKE   :: T  = 4.32  # Unresolved turbulence parameter
+    CKE₀  :: T  = 1e-11 # Minimum unresolved turbulence kinetic energy
 
-    KU₀   :: T  # Interior viscosity for velocity
-    KT₀   :: T  # Interior diffusivity for temperature
-    KS₀   :: T  # Interior diffusivity for salinity
+    KU₀   :: T  = 1e-6  # Interior viscosity for velocity
+    KT₀   :: T  = 1e-7  # Interior diffusivity for temperature
+    KS₀   :: T  = 1e-9  # Interior diffusivity for salinity
 end
 
-function Parameters(T=Float64;
-      CSL = 0.1,
-       Cτ = 0.4,
-      CNL = 6.33,
-    Cstab = 2.0,
-    Cunst = 6.4,
-     Cb_U = 0.599,
-     Cb_T = 1.36,
-     Cd_U = 0.5,
-     Cd_T = 2.5,
-      CRi = 0.3,
-      CKE = 4.32,
-       Cn = 1.0,
-    Cmτ_U = 1/4,
-    Cmτ_T = 1/2,
-    Cmb_U = 1/3,
-    Cmb_T = 1/3,
-       K₀ = 1e-5, KU₀=K₀, KT₀=K₀, KS₀=K₀,
-     # These should not be changed under ordinary circumstances:
-     CKE₀ = 1e-11,
-     Cτb_U = (Cτ / Cb_U)^(1/Cmb_U) * (1 + Cunst*Cd_U)^(Cmτ_U/Cmb_U) - Cd_U,
-     Cτb_T = (Cτ / Cb_T)^(1/Cmb_T) * (1 + Cunst*Cd_T)^(Cmτ_T/Cmb_T) - Cd_T
-     )
-
-     Parameters{T}(CSL, Cτ, CNL, Cstab, Cunst,
-                   Cb_U, Cτb_U, Cb_T, Cτb_T, Cd_U, Cd_T,
-                   CRi, CKE, CKE₀,
-                   Cn, Cmτ_U, Cmτ_T,Cmb_U, Cmb_T,
-                   KU₀, KT₀, KS₀)
-end
-
-# Shape functions (these shoul become parameters eventually).
+# Shape functions.
 # 'd' is a non-dimensional depth coordinate.
 default_shape_N(d) = 0 < d < 1 ? d*(1-d)^2 : 0
 const default_shape_K = default_shape_N

--- a/src/models/pacanowski_philander.jl
+++ b/src/models/pacanowski_philander.jl
@@ -15,25 +15,13 @@ import .KPP: ∂B∂z
 const nsol = 4
 @solution U V T S
 
-struct Parameters{T} <: AbstractParameters
-    Cν₀ :: T
-    Cν₁ :: T
-    Cκ₀ :: T
-    Cκ₁ :: T
-    Cc  :: T
-    Cn  :: T
-end
-
-function Parameters(T=Float64;
-    ν₀ = 1e-4,
-    ν₁ = 1e-2,
-    κ₀ = 1e-5,
-    κ₁ = 1e-2,
-    c  = 5,
-    n  = 2
-    )
-
-    Parameters{T}(ν₀, ν₁, κ₀, κ₁, c, n)
+Base.@kwdef struct Parameters{T} <: AbstractParameters
+    Cν₀ :: T = 1e-4
+    Cν₁ :: T = 1e-2
+    Cκ₀ :: T = 1e-5
+    Cκ₁ :: T = 1e-2
+    Cc  :: T = 5.0
+    Cn  :: T = 2.0
 end
 
 struct Model{TS, G, T} <: AbstractModel{TS, G, T}

--- a/test/kpptests.jl
+++ b/test/kpptests.jl
@@ -188,7 +188,7 @@ function test_update_state(; N=10, L=20, Fθ=5.1e-3)
 end
 
 function test_bulk_richardson_number(; g=9.81, α=2.1e-4, CRi=0.3, CKE=1.04,
-                                       CKE₀=0, γ=0.01, N=20, L=20, Fb=2.1e-5)
+                                       CKE₀=0.0, γ=0.01, N=20, L=20, Fb=2.1e-5)
     parameters = KPP.Parameters(CRi=CRi, CKE=CKE, CKE₀=CKE₀, CSL=0.1/N)
     constants = KPP.Constants(g=g, α=α)
     model = KPP.Model(N=N, L=L, parameters=parameters, constants=constants)
@@ -224,7 +224,7 @@ end
 
 function test_mixing_depth_convection(; g=9.81, α=2.1e-4, CRi=0.3, CKE=1.04,
                                        γ=0.01, N=200, L=20, Fb=4.1e-5)
-    parameters = KPP.Parameters(CRi=CRi, CKE=CKE, CKE₀=0, CSL=0.1/N)
+    parameters = KPP.Parameters(CRi=CRi, CKE=CKE, CKE₀=0.0, CSL=0.1/N)
     constants = KPP.Constants(g=g, α=α)
     model = KPP.Model(N=N, L=L, parameters=parameters, constants=constants)
     U, V, T, S = model.solution
@@ -249,10 +249,10 @@ function test_mixing_depth_convection(; g=9.81, α=2.1e-4, CRi=0.3, CKE=1.04,
     isapprox(h, h_answer, rtol=1e-3)
 end
 
-function test_mixing_depth_shear(; CSL=0.5, N=20, L=20, CRi=1)
+function test_mixing_depth_shear(; CSL=0.5, N=20, L=20, CRi=1.0)
     T₀ = 1
     U₀ = 3
-    parameters = KPP.Parameters(CRi=CRi, CSL=CSL, CKE₀=0)
+    parameters = KPP.Parameters(CRi=CRi, CSL=CSL, CKE₀=0.0)
     constants = KPP.Constants(g=1, α=1)
     model = KPP.Model(N=N, L=L, parameters=parameters, constants=constants)
     U, V, T, S = model.solution
@@ -313,7 +313,7 @@ end
 
 function test_turb_velocity_pure_convection(N=20, L=20, Cb_U=3.1, Cb_T=1.7, CSL=1e-16)
     # Zero wind + convection => w_scale_U = Cb_U * CSL^(1/3) * ωb.
-    parameters = KPP.Parameters(CRi=1, CKE=1, CKE₀=0, CSL=CSL, Cb_U=Cb_U, Cb_T=Cb_T)
+    parameters = KPP.Parameters(CRi=1.0, CKE=1.0, CKE₀=0.0, CSL=CSL, Cb_U=Cb_U, Cb_T=Cb_T)
     constants = KPP.Constants(g=1, α=1)
     model = KPP.Model(N=N, L=L, parameters=parameters, constants=constants)
     U, V, T, S = model.solution
@@ -336,7 +336,7 @@ function test_turb_velocity_pure_convection(N=20, L=20, Cb_U=3.1, Cb_T=1.7, CSL=
      KPP.w_scale_S(model, i) ≈ Cb_T * CSL^(1/3) * ωb )
 end
 
-function test_turb_velocity_pure_wind(; CSL=0.5, Cτ=0.7, N=20, L=20, CRi=1)
+function test_turb_velocity_pure_wind(; CSL=0.5, Cτ=0.7, N=20, L=20, CRi=1.0)
     T₀ = 1
     U₀ = 3
     parameters = KPP.Parameters(CRi=CRi, Cτ=Cτ, CSL=CSL)
@@ -365,7 +365,7 @@ function test_turb_velocity_pure_wind(; CSL=0.5, Cτ=0.7, N=20, L=20, CRi=1)
 end
 
 
-function test_turb_velocity_wind_stab(; CSL=0.5, Cτ=0.7, N=20, L=20, CRi=1, Cstab=0.3)
+function test_turb_velocity_wind_stab(; CSL=0.5, Cτ=0.7, N=20, L=20, CRi=1.0, Cstab=0.3)
     T₀ = 1
     U₀ = 3
     parameters = KPP.Parameters(CRi=CRi, Cτ=Cτ, CSL=CSL, Cstab=Cstab)
@@ -399,11 +399,11 @@ function test_turb_velocity_wind_stab(; CSL=0.5, Cτ=0.7, N=20, L=20, CRi=1, Cst
      KPP.w_scale_S(model, id) ≈ w_scale )
 end
 
-function test_turb_velocity_wind_unstab(; CKE=0, CSL=0.5, Cτ=0.7, N=20,
+function test_turb_velocity_wind_unstab(; CKE=0.0, CSL=0.5, Cτ=0.7, N=20,
                                         L=20, CRi=(1-0.5CSL), Cunst=0.3)
     T₀ = 1
     U₀ = 3
-    parameters = KPP.Parameters(CRi=CRi, Cτ=Cτ, CKE=CKE, CKE₀=0,
+    parameters = KPP.Parameters(CRi=CRi, Cτ=Cτ, CKE=CKE, CKE₀=0.0,
                                 CSL=CSL, Cunst=Cunst, Cd_U=Inf, Cd_T=Inf)
     constants = KPP.Constants(g=1, α=1)
     model = KPP.Model(N=N, L=L, parameters=parameters, constants=constants)
@@ -445,12 +445,12 @@ function test_turb_velocity_wind_unstab(; CKE=0, CSL=0.5, Cτ=0.7, N=20,
      KPP.w_scale_S(model, id2) ≈ w_scale_T2 )
 end
 
-function test_conv_velocity_wind(; CKE=0, CKE₀=0, CSL=0.5, Cτ=0.7, N=20, L=20, CRi=(1-0.5CSL),
+function test_conv_velocity_wind(; CKE=0.0, CKE₀=0.0, CSL=0.5, Cτ=0.7, N=20, L=20, CRi=(1-0.5CSL),
                                  Cb_U=1.1, Cb_T=0.1)
     T₀ = 1
     U₀ = 3
 
-    parameters = KPP.Parameters(CRi=CRi, Cτ=Cτ, CKE=CKE, CKE₀=0, CSL=CSL, Cd_U=0, Cd_T=0,
+    parameters = KPP.Parameters(CRi=CRi, Cτ=Cτ, CKE=CKE, CKE₀=0.0, CSL=CSL, Cd_U=0.0, Cd_T=0.0,
                                 Cb_U=1.1, Cb_T=0.1)
 
     constants = KPP.Constants(g=1, α=1)
@@ -498,7 +498,7 @@ function test_conv_velocity_wind(; CKE=0, CKE₀=0, CSL=0.5, Cτ=0.7, N=20, L=20
 end
 
 function test_diffusivity_plain(; K₀=1.1)
-    parameters = KPP.Parameters(K₀=K₀)
+    parameters = KPP.Parameters(KU₀=K₀, KT₀=K₀, KS₀=K₀)
     model = KPP.Model(parameters=parameters)
     KPP.update_state!(model)
 
@@ -522,7 +522,7 @@ end
 
 
 function test_kpp_diffusion_cosine(stepper=:ForwardEuler)
-    parameters = KPP.Parameters(K₀=1)
+    parameters = KPP.Parameters(KT₀=1.0, KS₀=1.0)
     model = KPP.Model(N=100, L=π/2, parameters=parameters, stepper=stepper)
     z = model.grid.zc
 

--- a/test/pptests.jl
+++ b/test/pptests.jl
@@ -8,7 +8,7 @@ function test_pp_basic()
 end
 
 function test_pp_diffusion_cosine()
-    parameters = PacanowskiPhilander.Parameters(κ₀=1, κ₁=0)
+    parameters = PacanowskiPhilander.Parameters(Cκ₀=1.0, Cκ₁=0.0)
     model = PacanowskiPhilander.Model(N=100, L=π/2, parameters=parameters)
     z = model.grid.zc
 


### PR DESCRIPTION
This minor PR updates KPP and Pacanowski-Philander modules to use `Base.@kwdef` to define `Parameter` structs with keyword constructors.