### PR TITLE
Bugfix for run_until! function

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -117,7 +117,7 @@ function run_until!(model, dt, tfinal)
     nt = floor(Int, (tfinal - time(model))/dt)
     iterate!(model, dt, nt)
 
-    last_dt = time(model) - tfinal
+    last_dt = tfinal - time(model)
     iterate!(model, last_dt)
     return nothing
 end

--- a/test/diffusiontests.jl
+++ b/test/diffusiontests.jl
@@ -44,6 +44,24 @@ function test_diffusion_cosine(stepper=:ForwardEuler)
     norm(c_ans.(z, time(model)) .- data(model.solution.c)) < model.grid.N*1e-6
 end
 
+function test_diffusion_cosine_run_until(stepper=:ForwardEuler)
+    model = Diffusion.Model(N=100, L=π/2, K=1.0, stepper=stepper)
+    z = model.grid.zc
+
+    c_init(z) = cos(2z)
+    c_ans(z, t) = exp(-4t) * c_init(z)
+
+    model.solution.c = c_init
+
+    dt = 1e-3
+    tfinal = 3dt/2
+    run_until!(model, dt, tfinal)
+
+    # The error tolerance is a bit arbitrary.
+    norm(c_ans.(z, tfinal) .- data(model.solution.c)) < model.grid.N*1e-6
+end
+
+
 function test_advection(stepper=:ForwardEuler)
     L = 1.0
     W = -1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,10 +7,15 @@ using
 # Run tests
 #
 
+steppers = (:ForwardEuler, :BackwardEuler)
+
 @testset "Utils" begin
     include("utilstests.jl")
     @test test_zeros(Float64)
     @test test_zeros(Float32)
+    for stepper in steppers
+        @test test_run_until(stepper)
+    end
 end
 
 @testset "Solvers" begin
@@ -66,8 +71,9 @@ end
     @test test_diffusion_basic()
     @test test_diffusion_set_c()
 
-    for stepper in (:ForwardEuler, :BackwardEuler)
+    for stepper in steppers
         @test test_diffusion_cosine(stepper)
+        @test test_diffusion_cosine_run_until(stepper)
         @test test_diffusive_flux(stepper, top_flux=0, bottom_flux=0)
         @test test_diffusive_flux(stepper)
         @test test_advection(stepper)
@@ -115,7 +121,7 @@ end
 
     @test test_diffusivity_plain()
 
-    for stepper in (:ForwardEuler, :BackwardEuler)
+    for stepper in steppers
         @test test_kpp_diffusion_cosine(stepper)
         for fieldname in (:U, :V, :T, :S)
             for top_flux in (0.3, -0.3)

--- a/test/utilstests.jl
+++ b/test/utilstests.jl
@@ -7,3 +7,12 @@ function test_zeros(T=Float64, dims=(13, 45))
   OceanTurb.@zeros T dims a2 b2
   eltype(a1) == T && a1 == a2 && b1 == b2
 end
+
+function test_run_until(stepper=:ForwardEuler)
+    model = Diffusion.Model(N=3, L=1, K=1.0, stepper=stepper)
+
+    dt, tfinal = 0.5, 1.3
+    run_until!(model, dt, tfinal)
+
+    return time(model) == tfinal
+end


### PR DESCRIPTION
This PR fixes a bug in the `run_until!` function in which the final time-step was calculated incorrectly (it was negative!)

It also adds two tests that will likely fail if `run_until!` has this sort of bug.

Thanks to @sandreza for catching this bug in #58.