### PR TITLE
Adds general diffusive flux util and nonlocal flux util for KPP

### DIFF
--- a/src/models/diffusion.jl
+++ b/src/models/diffusion.jl
@@ -11,11 +11,11 @@ Base.@kwdef struct Parameters{T} <: AbstractParameters
     μ :: T = 0.0
 end
 
-struct Model{P, TS, G, T} <: AbstractModel{TS, G, T}
+struct Model{P, TS, G, T, S} <: AbstractModel{TS, G, T}
     clock       :: Clock{T}
     grid        :: G
     timestepper :: TS
-    solution    :: Solution
+    solution    :: S
     bcs         :: BoundaryConditions
     parameters  :: P
 end
@@ -29,9 +29,9 @@ function Model(; N=10, L=1.0, K=0.1, W=0.0, μ=0.0,
 
     solution = Solution(CellField(grid))
 
-      K = (Kc,)
-      W = (Wc,)
-      L = (Lc,)
+      K = (c=Kc,)
+      W = (c=Wc,)
+      L = (c=Lc,)
 
     eqn = Equation(K=K, M=W, L=L)
     lhs = build_lhs(solution)

--- a/src/models/k_profile_parameterization.jl
+++ b/src/models/k_profile_parameterization.jl
@@ -374,4 +374,34 @@ const KV = KU
 @propagate_inbounds RT(m, i) = - ∂NLT∂z(m, i)
 @propagate_inbounds RS(m, i) = - ∂NLS∂z(m, i)
 
+#####
+##### Some utilities
+#####
+
+function nonlocal_salinity_flux!(flux, m)
+    for i in interiorindices(flux)
+        @inbounds flux[i] = NL(m.parameters.CNL, m.state.Fs, d(m, i))
+    end
+    return nothing
+end
+
+function nonlocal_temperature_flux!(flux, m)
+    for i in interiorindices(flux)
+        @inbounds flux[i] = NL(m.parameters.CNL, m.state.Fθ, d(m, i))
+    end
+    return nothing
+end
+
+function nonlocal_salinity_flux(model)
+    flux = FaceField(model.grid)
+    nonlocal_salinity_flux!(flux, model)
+    return flux
+end
+
+function nonlocal_temperature_flux(model)
+    flux = FaceField(model.grid)
+    nonlocal_temperature_flux!(flux, model)
+    return flux
+end
+
 end # module

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -119,5 +119,35 @@ function run_until!(model, dt, tfinal)
 
     last_dt = tfinal - time(model)
     iterate!(model, last_dt)
+
     return nothing
+end
+
+"""
+    diffusive_flux!(flux, fieldname, model)
+
+Calculates the diffusive flux associated with `fieldname` in `model.solution.fieldname`i
+and stores the result in the `FaceField` `flux`.
+"""
+function diffusive_flux!(flux, fieldname, model)
+    field = getproperty(model.solution, fieldname)
+    K = getproperty(model.timestepper.eqn.K, fieldname)
+
+    for i in interiorindices(flux)
+        @inbounds flux[i] = - K(model, i) * ∂z(field, i)
+    end
+
+    return nothing
+end
+
+"""
+    diffusive_flux(fieldname, model)
+
+Returns `flux::FaceField` with the diffusive flux associated with `fieldname` 
+in `model.solution.fieldname`.
+"""
+function diffusive_flux(fieldname, model)
+    flux = FaceField(model.grid)
+    diffusive_flux!(flux, fieldname, model)
+    return flux
 end

--- a/test/kpptests.jl
+++ b/test/kpptests.jl
@@ -142,7 +142,6 @@ function test_Δ3(; CSL=0.5, N=20, L=20)
     KPP.Δ(U, CSL, ih) == U₀
 end
 
-
 function test_buoyancy_gradient(; γ=0.01, g=9.81, ρ₀=1028, α=2e-4, β=0.0, N=10, L=1.0)
     model = KPP.Model(N=N, L=L)
     T₀(z) = γ*z
@@ -562,3 +561,30 @@ function test_flux(stepper=:ForwardEuler; fieldname=:U, top_flux=0.3, bottom_flu
 
     return C(time(model)) ≈ integral(c)
 end
+
+function test_nonlocal_salinity_flux_util(N=4, L=4.3)
+    model = KPP.Model(N=N, L=L)
+
+    try
+        flux = KPP.nonlocal_salinity_flux(model)
+    catch err
+        @error sprint(showerror, err)
+        return false
+    end
+
+    return true
+end
+
+function test_nonlocal_temperature_flux_util(N=4, L=4.3)
+    model = KPP.Model(N=N, L=L)
+
+    try
+        flux = KPP.nonlocal_temperature_flux(model)
+    catch err
+        @error sprint(showerror, err)
+        return false
+    end
+
+    return true
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ steppers = (:ForwardEuler, :BackwardEuler)
     include("utilstests.jl")
     @test test_zeros(Float64)
     @test test_zeros(Float32)
+    @test test_diffusive_flux()
     for stepper in steppers
         @test test_run_until(stepper)
     end
@@ -129,6 +130,9 @@ end
             end
         end
     end
+
+    @test test_nonlocal_salinity_flux_util()
+    @test test_nonlocal_temperature_flux_util()
 end
 
 @testset "Pacanowski-Philander" begin

--- a/test/utilstests.jl
+++ b/test/utilstests.jl
@@ -16,3 +16,11 @@ function test_run_until(stepper=:ForwardEuler)
 
     return time(model) == tfinal
 end
+
+function test_diffusive_flux()
+    model = Diffusion.Model(N=4, L=2, K=0.1)
+    c0(z) = z
+    model.solution.c = c0
+    flux = OceanTurb.diffusive_flux(:c, model)
+    return flux[2] == -0.1
+end


### PR DESCRIPTION
This PR adds

* `OceanTurb.diffusive_flux(fieldname, model)`
* `OceanTurb.diffusive_flux!(flux, fieldname, model)`
* `OceanTurb.KPP.nonlocal_salinity_flux(fieldname, model)`
* `OceanTurb.KPP.nonlocal_salinity_flux!(flux, fieldname, model)`
* `OceanTurb.KPP.nonlocal_temperature_flux(fieldname, model)`
* `OceanTurb.KPP.nonlocal_temperature_flux!(flux, fieldname, model)`

`fieldname` is a symbol; so for KPP one could write

```julia
flux = OceanTurb.diffusive_flux(:U, model)
```

to get the diffusive flux associated with `U`.

The flux can also be pre-allocated to avoid memory allocation:

```julia
flux = FaceField(model.grid)
OceanTurb.diffusive_flux!(flux, :U, model)
```

The functions `nonlocal_`... have a similar usage, but are located inside the `KPP` module.

Resolves #61. 

cc @sandreza 

