### PR TITLE
Modularize TKE eddy diffusivities

### DIFF
--- a/src/models/TKEMassFlux/diffusivities.jl
+++ b/src/models/TKEMassFlux/diffusivities.jl
@@ -1,0 +1,40 @@
+#
+# Background diffusivity parameters
+#
+
+Base.@kwdef struct BackgroundDiffusivities{T} <: AbstractParameters
+    KU₀ :: T = 1e-6 # Background viscosity for momentum
+    KC₀ :: T = 1e-6 # Background diffusivity for tracers
+end
+
+@inline KU₀(m) = m.background_diffusivities.KU₀
+@inline KC₀(m) = m.background_diffusivities.KC₀
+
+#
+# Eddy diffusivity parameters
+#
+
+"""
+    struct SinglePrandtlParameters{T} <: AbstractParameters
+
+A `simple' Prandtl number model that assumes the TKE diffusivity is identical
+to the tracer diffusivity. The momentum diffusivity parameter is Cᴷu, and the 
+tracer diffusivities equal to the momentum diffusivity divided by CᴷPr.
+"""
+Base.@kwdef struct SinglePrandtlDiffusivities{T} <: AbstractParameters
+     Cᴷu :: T = 0.1   # Diffusivity parameter for velocity
+    CᴷPr :: T = 0.74  # Diffusivity parameter for velocity
+end
+
+const SPD = SinglePrandtlDiffusivities
+
+@inline KU(m::Model{L, <:SPD}, i) where L = KU₀(m) + m.eddy_diffusivities.Cᴷu * onface(m.state.K, i)
+@inline KV(m::Model{L, <:SPD}, i) where L = KU(m, i)
+
+# All tracers share diffusivity.
+@inline KC(m::Model{L, <:SPD}, i) where L = KC₀(m) + m.eddy_diffusivities.Cᴷu /
+                                                     m.eddy_diffusivities.CᴷPr * onface(m.state.K, i)
+
+@inline KT(m::Model{L, <:SPD}, i) where L = KC(m, i)
+@inline KS(m::Model{L, <:SPD}, i) where L = KC(m, i)
+@inline Ke(m::Model{L, <:SPD}, i) where L = KC(m, i)

--- a/src/models/TKEMassFlux/tke_equation.jl
+++ b/src/models/TKEMassFlux/tke_equation.jl
@@ -1,13 +1,5 @@
 Base.@kwdef struct TKEParameters{T} <: AbstractParameters
-      Cᴰ :: T = 0.33  # Dissipation parameter
-     Cᴷu :: T = 0.1   # Diffusivity parameter for velocity
-    CᴷPr :: T = 0.74  # Diffusivity parameter for velocity
-#     Cᴷe :: T = 0.1   # Ratio between turbulent kinetic energy and momentum diffusivity
-
-    KU₀ :: T = 1e-6 # Interior viscosity for velocity
-    KT₀ :: T = 1e-6 # Interior diffusivity for temperature
-    KS₀ :: T = 1e-6 # Interior diffusivity for salinity
-    Ke₀ :: T = 1e-6 # Interior diffusivity for salinity
+    Cᴰ :: T = 0.33  # Dissipation parameter
 end
 
 # Note: to increase readability, we use 'm' to refer to 'model' in function
@@ -18,7 +10,6 @@ end
 @inline ∂z_T(m, i) = ∂z(m.solution.T, i)
 @inline ∂z_S(m, i) = ∂z(m.solution.S, i)
 
-# Fallback for linear equations of state.
 @inline buoyancy_flux(m, i) = - m.constants.g * (  m.constants.α * KT(m, i) * oncell(∂z_T, m, i)
                                                  - m.constants.β * KS(m, i) * oncell(∂z_S, m, i))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,14 +9,14 @@ using
 
 steppers = (:ForwardEuler, :BackwardEuler)
 
-#include("test_utils.jl")
-#include("test_solvers.jl")
-#include("test_grids.jl")
-#include("test_fields.jl")
+include("test_utils.jl")
+include("test_solvers.jl")
+include("test_grids.jl")
+include("test_fields.jl")
 
 # Models
-#include("test_diffusion.jl")
-#include("test_pp.jl")
-#include("test_kpp.jl")
-#include("test_modularkpp.jl")
+include("test_diffusion.jl")
+include("test_pp.jl")
+include("test_kpp.jl")
+include("test_modularkpp.jl")
 include("test_tkemassflux.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,14 +9,14 @@ using
 
 steppers = (:ForwardEuler, :BackwardEuler)
 
-include("test_utils.jl")
-include("test_solvers.jl")
-include("test_grids.jl")
-include("test_fields.jl")
+#include("test_utils.jl")
+#include("test_solvers.jl")
+#include("test_grids.jl")
+#include("test_fields.jl")
 
 # Models
-include("test_diffusion.jl")
-include("test_pp.jl")
-include("test_kpp.jl")
-include("test_modularkpp.jl")
+#include("test_diffusion.jl")
+#include("test_pp.jl")
+#include("test_kpp.jl")
+#include("test_modularkpp.jl")
 include("test_tkemassflux.jl")

--- a/test/test_tkemassflux.jl
+++ b/test/test_tkemassflux.jl
@@ -38,16 +38,15 @@ tke_equation_models = (
 
 mixing_length_models = (
     TKEMassFlux.SimpleMixingLength(),
-    TKEMassFlux.TanEtAl2018MixingLength(),
     TKEMassFlux.EquilibriumMixingLength(),
 )
 
 wall_models = (
     nothing,
     TKEMassFlux.PrescribedNearWallTKE(),
-    TKEMassFlux.SurfaceValueScaling(),
-    TKEMassFlux.SurfaceTKEProductionModel(),
-    TKEMassFlux.MixedSurfaceTKEProductionModel(),
+    TKEMassFlux.PrescribedSurfaceTKEValue(),
+    TKEMassFlux.PrescribedSurfaceTKEFlux(),
+    TKEMassFlux.DynamicSurfaceTKEFlux(),
 )
 
 @testset "TKEMassFlux" begin


### PR DESCRIPTION
This PR puts the eddy diffusivity parameters in their own struct so that multiple models for the TKE eddy diffusivities can be entertained simultaneously.