### PR TITLE
Fix diagnostic plumes

### DIFF
--- a/docs/src/models/modular_kpp.md
+++ b/docs/src/models/modular_kpp.md
@@ -398,7 +398,8 @@ is instantiated by writing
 nonlocalflux = DiagnosticPlumeModel()
 ```
 
-The diagnostic plume model
+The diagnostic plume model described by
+[Siebesma et al (2007)](https://journals.ametsoc.org/doi/full/10.1175/JAS3888.1)
 integrates equations that describe the quasi-equilibrium vertical momentum and 
 tracer budgets for plumes that plunge downwards from the ocean surface
 due to destabilizing buoyancy flux. 
@@ -414,17 +415,6 @@ vertical velocity, and ``\breve \Phi`` is plume-averaged concentration of the
 tracer ``\phi``.
 When using a plume model in `ModularKPP`, ``\Phi`` must be interpreted as
 the average concentration of ``\phi`` in the environment, excluding plume regions.
-in `OceanTurb.jl`'s implementation of the
-[Siebesma et al (2007)](https://journals.ametsoc.org/doi/full/10.1175/JAS3888.1)
-the plume vertical velocity variance ``\breve W^2`` is used as a diagnostic variable, 
-rather than ``\breve W``. Due to this, the nonlocal flux in `OceanTurb.jl` becomes
-```math
-\beq
-    NL_\phi = -\C{a}{} \sqrt{\breve W^2} \left ( \Phi - \breve \Phi \right ) \, ,
-\eeq
-```
-where we assume that ``\breve W \le 0``.
-
 
 #### Continuous plume equations
 
@@ -437,18 +427,21 @@ The diagnostic, steady-state plume-averaged temperature and salinity budgets boi
 ```
 where ``\breve T`` and ``\breve S`` are the plume-averaged temperature and salinity, 
 and ``T`` and ``S`` are the environment-averaged temperature and salinity and 
-``\epsilon(z, h)`` is the parameterized entrainment rate, 
+``\epsilon(z, h)`` is the parameterized entrainment length, 
 ```math
-\beq
-\epsilon(z) = \C{\epsilon}{} 
-    \left [ \frac{1}{\Delta c_N - z} + \frac{1}{\Delta c_N + \left ( z + h \right )} \right ] \, ,
-\eeq
+\begin{align}
+\epsilon(z) &\equiv \frac{E}{\C{a}{} \breve W} \, , \\
+    &= -\C{\epsilon}{} 
+        \left [ \frac{1}{\Delta c_N - z} + \frac{1}{\Delta c_N + \left ( z + h \right )} \right ] \, ,
+\end{align}
 ```
 where ``\C{\epsilon}{} = 0.4``, ``\Delta c_N`` is the spacing between the boundary and the topmost
 cell interface, and ``h`` is the mixing depth determined via the chosen mixing depth model.
+We note that the definition of ``\epsilon`` in terms of the positive-definite 
+entrainment rate ``E>0``, area fraction ``\C{a}{}``, and negative-definite downdraft plume
+velocity ``\breve W`` implies that ``\epsilon < 0``.
 
 The budget for plume vertical momentum is
-
 ```math
 \beq
     \d_z \breve W^2 = \C{b}{w} \left ( \breve B - B \right ) - \C{\epsilon}{w} \epsilon \, \breve W^2
@@ -489,8 +482,8 @@ through the ocean surface,
 \eeq
 ```
 
-The advetion terms in the diagnostic plume equations are discretized with an downwind 
-scheme, which permits integration of each equation from the surface downward.
+The advection terms in the diagnostic plume equations are discretized with an downwind 
+scheme, !(isfinite(ϕᵢ))ntegration of each equation from the surface downward.
 The plume temperature advection term, for example, is defined at cell centers
 and discretized with
 

--- a/examples/diagnostic_plumes.jl
+++ b/examples/diagnostic_plumes.jl
@@ -1,4 +1,4 @@
-using OceanTurb, Printf
+using OceanTurb, Printf 
 
 using OceanTurb.ModularKPP: DiagnosticPlumeModel
 
@@ -6,12 +6,40 @@ using OceanTurb.ModularKPP: DiagnosticPlumeModel
 
 usecmbright()
 
+function makeplot!(axs, model)
+    ΔT = model.state.plume.T - model.solution.T
+
+    ϵ = CellField(model.grid)
+    for i in eachindex(ϵ)
+        @inbounds ϵ[i] = ModularKPP.entrainment(model.grid.zc[i], model)
+    end
+
+    for ax in axs
+        sca(ax); cla()
+    end
+
+    sca(axs[1])
+    plot(ΔT)
+
+    sca(axs[2])
+    plot(model.solution.T)
+    plot(model.state.plume.T, "--")
+
+    sca(axs[3])
+    plot(model.state.plume.W²)
+
+    sca(axs[4])
+    plot(ϵ)
+
+    return nothing
+end
+
 modelsetup = (N=256, L=256, stepper=:BackwardEuler)
 
 Fb = 1e-7
 Fu = 0.0
 N² = 1e-5
-Δt = 2minute
+Δt = 1minute
 t_plot = (0hour, 12hour, 48hour)
 
 name = "Free convection
@@ -24,8 +52,8 @@ model = ModularKPP.Model(; modelsetup...,
 # Initial condition and fluxes
 dTdz = N² / (model.constants.α * model.constants.g)
 T₀(z) = 20 + dTdz*z
-
 model.solution.T = T₀
+OceanTurb.set!(model.state.plume.T, T₀)
 
 Fθ = Fb / (model.constants.α * model.constants.g)
 model.bcs.U.top = FluxBoundaryCondition(Fu)
@@ -33,20 +61,16 @@ model.bcs.U.top = FluxBoundaryCondition(Fu)
 model.bcs.T.top = FluxBoundaryCondition(Fθ)
 model.bcs.T.bottom = GradientBoundaryCondition(dTdz)
 
-iterate!(model, Δt)
+fig, axs = subplots(ncols=4, sharey=true)
 
-#ModularKPP.update_state!(model)
+sca(axs[1]); xlabel(L"\Delta T")
+sca(axs[2]); xlabel(L"T")
+sca(axs[3]); xlabel(L"\overline{w^2}")
+sca(axs[4]); xlabel(L"\epsilon")
 
-ΔT = model.state.plumes.T - model.solution.T
+#iterate!(model, Δt)
 
-fig, axs = subplots(ncols=3)
+ModularKPP.update_state!(model)
+makeplot!(axs, model)
 
-sca(axs[1])
-plot(ΔT)
-
-sca(axs[2])
-plot(model.solution.T)
-plot(model.state.plumes.T)
-
-sca(axs[3])
-plot(model.state.plumes.W²)
+#makeplot!(axs, model)

--- a/src/models/ModularKPP/ModularKPP.jl
+++ b/src/models/ModularKPP/ModularKPP.jl
@@ -141,7 +141,7 @@ RS(m, i) = - ∂z_explicit_nonlocal_flux_S(m, i) + m.forcing.S(m, i)
 
 MU(m, i) = 0
 MV(m, i) = 0
-MT(m, i) = mass_flux(m, i)
-MS(m, i) = mass_flux(m, i)
+MT(m, i) = -mass_flux(m, i)
+MS(m, i) = -mass_flux(m, i)
 
 end # module

--- a/src/models/ModularKPP/ModularKPP.jl
+++ b/src/models/ModularKPP/ModularKPP.jl
@@ -101,8 +101,8 @@ function Model(; N=10, L=1.0,
 
      K = Accessory{Function}(KU, KV, KT, KS)
      R = Accessory{Function}(RU, RV, RT, RS)
-     M = Accessory{Function}(MU, MV, MT, MS)
-    eq = Equation(K=K, R=R, M=M, update=update_state!)
+     A = Accessory{Function}(AU, AV, AT, AS)
+    eq = Equation(K=K, R=R, M=A, update=update_state!)
 
        state = State(diffusivity, nonlocalflux, mixingdepth, grid)
     solution = Solution((CellField(grid) for i=1:nsol)...)
@@ -139,9 +139,9 @@ const KV = KU
 RT(m, i) = - ∂z_explicit_nonlocal_flux_T(m, i) + m.forcing.T(m, i)
 RS(m, i) = - ∂z_explicit_nonlocal_flux_S(m, i) + m.forcing.S(m, i)
 
-MU(m, i) = 0
-MV(m, i) = 0
-MT(m, i) = -mass_flux(m, i)
-MS(m, i) = -mass_flux(m, i)
+AU(m, i) = 0
+AV(m, i) = 0
+AT(m, i) = - mass_flux(m, i)
+AS(m, i) = - mass_flux(m, i)
 
 end # module

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -116,6 +116,11 @@ end
     timestepper :: TS
 end
 
+"""
+    run_until!(model, dt, tfinal)
+
+Run `model` until `tfinal` with time-step `dt`.
+"""
 function run_until!(model, dt, tfinal)
     nt = floor(Int, (tfinal - time(model))/dt)
     iterate!(model, dt, nt)
@@ -129,7 +134,7 @@ end
 """
     diffusive_flux!(flux, fieldname, model)
 
-Calculates the diffusive flux associated with `fieldname` in `model.solution.fieldname`i
+Calculates the diffusive flux associated with `fieldname` in `model.solution.fieldname`
 and stores the result in the `FaceField` `flux`.
 """
 function diffusive_flux!(flux, fieldname, model)


### PR DESCRIPTION
This PR fixes diagnostic plumes in ModularKPP. So far they only work with ForwardEuler timestepping.