### PR TITLE
Change default TKE parameteres

### DIFF
--- a/examples/timestepping_error_analysis.jl
+++ b/examples/timestepping_error_analysis.jl
@@ -4,7 +4,7 @@ using OceanTurb, OceanTurb.Diffusion, LinearAlgebra
 @use_pyplot_utils
 
 # First, we define the model.
-model = Diffusion.Model(N=100, H=π/2, K=1.0)
+model = Diffusion.Model(N=100, H=π/2, K=1.0, stepper=:ForwardEuler)
 z = model.grid.zc
 
 c_init(z) = cos(2z)

--- a/src/models/TKEMassFlux/diffusivities.jl
+++ b/src/models/TKEMassFlux/diffusivities.jl
@@ -57,9 +57,9 @@ A diffusivity model in which momentum, tracers, and TKE
 each have their own diffusivity parameter.
 """
 Base.@kwdef struct IndependentDiffusivities{T} <: AbstractParameters
-     Cᴷu :: T = 0.07549  # Diffusivity parameter for velocity
-     Cᴷc :: T = 0.08382  # Diffusivity parameter for tracers
-     Cᴷe :: T = 0.4757   # Diffusivity parameter for TKE
+     Cᴷu :: T = 0.0274 # Diffusivity parameter for velocity
+     Cᴷc :: T = 0.0498 # Diffusivity parameter for tracers
+     Cᴷe :: T = 0.0329 # Diffusivity parameter for TKE
 end
 
 const IDP = IndependentDiffusivities 

--- a/src/models/TKEMassFlux/mixing_length.jl
+++ b/src/models/TKEMassFlux/mixing_length.jl
@@ -11,8 +11,8 @@
 
 Base.@kwdef struct SimpleMixingLength{T} <: AbstractParameters
     Cᴸᵟ :: T = 1.0
-    Cᴸʷ :: T = 0.4
-    Cᴸᵇ :: T = 0.64
+    Cᴸʷ :: T = 3.4684
+    Cᴸᵇ :: T = 3.9302
 end
 
 @inline function mixing_length(m::Model{<:SimpleMixingLength}, i)

--- a/src/models/TKEMassFlux/tke_equation.jl
+++ b/src/models/TKEMassFlux/tke_equation.jl
@@ -1,5 +1,5 @@
 Base.@kwdef struct TKEParameters{T} <: AbstractParameters
-    Cᴰ :: T = 1.891 # Dissipation parameter
+    Cᴰ :: T = 3.2441 # Dissipation parameter
 end
 
 # Note: to increase readability, we use 'm' to refer to 'model' in function

--- a/src/models/TKEMassFlux/wall_models.jl
+++ b/src/models/TKEMassFlux/wall_models.jl
@@ -39,7 +39,7 @@ TKEValueSurfaceConditions(T, wall_model::PrescribedSurfaceTKEValue) =
 #
 
 Base.@kwdef struct PrescribedSurfaceTKEFlux{T} <: AbstractParameters
-    Cʷu★ :: T = 2.0
+    Cʷu★ :: T = 1.3717
     CʷwΔ :: T = 1.0
 end
 


### PR DESCRIPTION
This PR changes the default TKE parameters in `IndependentDiffusivities`, `TKEEquation`, `SimpleMixingLength`, and `PrescribeSurfaceTKEFlux` to

```
Cᴷu     Cᴷc     Cᴷe     Cᴰ      Cᴸʷ     Cᴸᵇ     Cʷu★    
0.0274  0.0498  0.0329  3.2441  3.4684  3.9302  1.3717
```

These parameters are the result of a preliminary optimization to data. This method is reported here:

<img width="1042" alt="image" src="https://user-images.githubusercontent.com/15271942/82837202-5bc2d680-9e96-11ea-808c-68e51d108db2.png">

These parameters are subject to change as the calibration is extended. Note that the free parameters of different models depend on one another in general, such that the optimal parameters proposed in this PR are only valid if each subcomponent is used. (This is true for all boundary layer parameterizations, even if is not common practice regularly change their free parameters.)